### PR TITLE
Error pages

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,12 +10,9 @@ import (
 	"os/signal"
 	"strings"
 
-	"html/template"
-
 	"github.com/G-Node/gin-valid/config"
 	"github.com/G-Node/gin-valid/helpers"
 	"github.com/G-Node/gin-valid/log"
-	"github.com/G-Node/gin-valid/resources/templates"
 	"github.com/G-Node/gin-valid/web"
 	"github.com/docopt/docopt-go"
 	"github.com/gorilla/handlers"
@@ -36,32 +33,8 @@ Options:
   --config=<path>     Path to a json server config file
   `
 
-func root(w http.ResponseWriter, r *http.Request) {
-	fail := func(status int, message string) {
-		log.Write("[error] %s", message)
-		w.WriteHeader(status)
-		w.Write([]byte(message))
-	}
-	if r.Method == http.MethodGet {
-		tmpl := template.New("layout")
-		tmpl, err := tmpl.Parse(templates.Layout)
-		if err != nil {
-			log.Write("[Error] failed to parse html layout page")
-			fail(http.StatusInternalServerError, "something went wrong")
-			return
-		}
-		tmpl, err = tmpl.Parse(templates.Root)
-		if err != nil {
-			log.Write("[Error] failed to render root page")
-			fail(http.StatusInternalServerError, "something went wrong")
-			return
-		}
-		tmpl.Execute(w, nil)
-	}
-}
-
 func registerRoutes(r *mux.Router) {
-	r.HandleFunc("/", root)
+	r.HandleFunc("/", web.Root)
 	r.HandleFunc("/pubvalidate", web.PubValidate)
 	r.HandleFunc("/validate/{service}/{user}/{repo}", web.Validate)
 	r.HandleFunc("/status/{service}/{user}/{repo}", web.Status)

--- a/web/fail.go
+++ b/web/fail.go
@@ -1,9 +1,11 @@
 package web
 
 import (
+	"html/template"
 	"net/http"
 
 	"github.com/G-Node/gin-valid/log"
+	"github.com/G-Node/gin-valid/resources/templates"
 )
 
 // fail logs an error and renders an error page with the given message,
@@ -11,5 +13,27 @@ import (
 func fail(w http.ResponseWriter, status int, message string) {
 	log.Write("[error] %s", message)
 	w.WriteHeader(status)
-	w.Write([]byte(message))
+
+	tmpl := template.New("layout")
+	tmpl, err := tmpl.Parse(templates.Layout)
+	if err != nil {
+		log.Write("[Error] failed to parse html layout page. Displaying error message without layout.")
+		tmpl = template.New("content")
+	}
+	tmpl, err = tmpl.Parse(templates.Fail)
+	if err != nil {
+		log.Write("[Error] failed to render fail page. Displaying plain error message.")
+		w.Write([]byte(message))
+		return
+	}
+	errinfo := struct {
+		StatusCode int
+		StatusText string
+		Message    string
+	}{
+		status,
+		http.StatusText(status),
+		message,
+	}
+	tmpl.Execute(w, &errinfo)
 }

--- a/web/fail.go
+++ b/web/fail.go
@@ -1,0 +1,15 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/G-Node/gin-valid/log"
+)
+
+// fail logs an error and renders an error page with the given message,
+// returning the given status code to the user.
+func fail(w http.ResponseWriter, status int, message string) {
+	log.Write("[error] %s", message)
+	w.WriteHeader(status)
+	w.Write([]byte(message))
+}

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -16,11 +16,6 @@ import (
 )
 
 func EnableHook(w http.ResponseWriter, r *http.Request) {
-	fail := func(status int, message string) {
-		log.Write("[error] %s", message)
-		w.WriteHeader(status)
-		w.Write([]byte(message))
-	}
 	if r.Method != "GET" {
 		return
 	}
@@ -33,20 +28,20 @@ func EnableHook(w http.ResponseWriter, r *http.Request) {
 	sessionid, err := r.Cookie(cookiename)
 	if err != nil {
 		msg := fmt.Sprintf("Hook creation failed: unauthorised")
-		fail(http.StatusUnauthorized, msg)
+		fail(w, http.StatusUnauthorized, msg)
 		return
 	}
 
 	session, ok := sessions[sessionid.Value]
 	if !ok {
 		msg := fmt.Sprintf("Hook creation failed: unauthorised")
-		fail(http.StatusUnauthorized, msg)
+		fail(w, http.StatusUnauthorized, msg)
 		return
 	}
 	repopath := fmt.Sprintf("%s/%s", user, repo)
 	err = createValidHook(repopath, service, session)
 	if err != nil {
-		fail(http.StatusUnauthorized, err.Error())
+		fail(w, http.StatusUnauthorized, err.Error())
 		return
 	}
 	http.Redirect(w, r, fmt.Sprintf("/repos/%s", session.Username), http.StatusFound)

--- a/web/user.go
+++ b/web/user.go
@@ -79,24 +79,19 @@ func doLogin(username, password string) (*usersession, error) {
 // Login renders the login form and logs in the user to the GIN server, storing
 // a session token and key.
 func Login(w http.ResponseWriter, r *http.Request) {
-	fail := func(status int, message string) {
-		log.Write("[error] %s", message)
-		w.WriteHeader(status)
-		w.Write([]byte(message))
-	}
 	if r.Method == http.MethodGet {
 		log.Write("Login page")
 		tmpl := template.New("layout")
 		tmpl, err := tmpl.Parse(templates.Layout)
 		if err != nil {
 			log.Write("[Error] failed to parse html layout page")
-			fail(http.StatusInternalServerError, "something went wrong")
+			fail(w, http.StatusInternalServerError, "something went wrong")
 			return
 		}
 		tmpl, err = tmpl.Parse(templates.Login)
 		if err != nil {
 			log.Write("[Error] failed to render login page")
-			fail(http.StatusInternalServerError, "something went wrong")
+			fail(w, http.StatusInternalServerError, "something went wrong")
 			return
 		}
 		tmpl.Execute(w, nil)
@@ -108,7 +103,7 @@ func Login(w http.ResponseWriter, r *http.Request) {
 		session, err := doLogin(username, password)
 		if err != nil {
 			log.Write("[error] Login failed: %s", err.Error())
-			fail(http.StatusUnauthorized, "authentication failed")
+			fail(w, http.StatusUnauthorized, "authentication failed")
 			return
 		}
 
@@ -140,11 +135,6 @@ func getSessionOrRedirect(w http.ResponseWriter, r *http.Request) (*usersession,
 // accessible) by a given user and renders the page which displays the
 // repositories and their validation status.
 func ListRepos(w http.ResponseWriter, r *http.Request) {
-	fail := func(status int, message string) {
-		log.Write("[error] %s", message)
-		w.WriteHeader(status)
-		w.Write([]byte(message))
-	}
 	if r.Method != http.MethodGet {
 		return
 	}
@@ -172,13 +162,13 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 	tmpl, err = tmpl.Parse(templates.Layout)
 	if err != nil {
 		log.Write("[Error] failed to parse html layout page")
-		fail(http.StatusInternalServerError, "something went wrong")
+		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.RepoList)
 	if err != nil {
 		log.Write("[Error] failed to render repository list page")
-		fail(http.StatusInternalServerError, "something went wrong")
+		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
 	repos := make([]repoHooksInfo, len(userrepos))
@@ -196,11 +186,6 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 // ShowRepo renders the repository information page where the user can enable or
 // disable validator hooks.
 func ShowRepo(w http.ResponseWriter, r *http.Request) {
-	fail := func(status int, message string) {
-		log.Write("[error] %s", message)
-		w.WriteHeader(status)
-		w.Write([]byte(message))
-	}
 	if r.Method != http.MethodGet {
 		return
 	}
@@ -233,13 +218,13 @@ func ShowRepo(w http.ResponseWriter, r *http.Request) {
 	tmpl, err = tmpl.Parse(templates.Layout)
 	if err != nil {
 		log.Write("[Error] failed to parse html layout page")
-		fail(http.StatusInternalServerError, "something went wrong")
+		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.RepoPage)
 	if err != nil {
 		log.Write("[Error] failed to render repository page")
-		fail(http.StatusInternalServerError, "something went wrong")
+		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
 


### PR DESCRIPTION
Render error pages in standard page layout and use common `fail()` function everywhere.