### PR TITLE
NewToken() function

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,16 +113,16 @@ func main() {
 	log.Write("[Warmup] cli arguments: %v\n", args)
 
 	// Use port if provided.
-	port := srvcfg.Settings.Port
+	var port string
 	if argport := args["--listen"]; argport != nil {
 		port = argport.(string)
 	}
 
-	if helpers.IsValidPort(port) {
-		port = fmt.Sprintf(":%s", port)
-	} else {
+	if !helpers.IsValidPort(port) {
 		log.ShowWrite("[Warning] could not parse a valid port number, using default")
+		port = srvcfg.Settings.Port
 	}
+	port = fmt.Sprintf(":%s", port)
 	log.ShowWrite("[Warmup] using port: '%s'", port)
 
 	log.ShowWrite("[Warmup] registering routes")

--- a/main.go
+++ b/main.go
@@ -36,12 +36,12 @@ Options:
 func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/", web.Root)
 	r.HandleFunc("/pubvalidate", web.PubValidate)
-	r.HandleFunc("/validate/{service}/{user}/{repo}", web.Validate)
-	r.HandleFunc("/status/{service}/{user}/{repo}", web.Status)
-	r.HandleFunc("/results/{service}/{user}/{repo}", web.Results)
+	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate)
+	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status)
+	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results)
 	r.HandleFunc("/login", web.Login)
 	r.HandleFunc("/repos/{user}", web.ListRepos)
-	r.HandleFunc("/repos/{user}/{repo}/{service}/enable", web.EnableHook)
+	r.HandleFunc("/repos/{user}/{repo}/{validator}/enable", web.EnableHook)
 	r.HandleFunc("/repos/{user}/{repo}/hooks", web.ShowRepo)
 }
 

--- a/run
+++ b/run
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-loc=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 set -euo pipefail
+loc=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
+pushd ${loc}
 
 go build
 docker build --tag=ginvalid .
@@ -12,7 +13,5 @@ cp -a "./srvdata/." "${srvdata}"
 
 configdir="${srvdata}/config"
 configfile="${configdir}/cfg.json"
-
-# TODO: If cfg does not exist, create empty
 
 docker run --rm --network=ginbridge -v ${srvdata}:/gin-valid -v ${configdir}:/config/ -p 3033:3033 --name ginvalid -it ginvalid

--- a/web/results.go
+++ b/web/results.go
@@ -100,16 +100,16 @@ func Results(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	user := vars["user"]
 	repo := vars["repo"]
-	service := strings.ToLower(vars["service"])
-	if !helpers.SupportedValidator(service) {
-		log.Write("[Error] unsupported validator '%s'\n", service)
+	validator := strings.ToLower(vars["validator"])
+	if !helpers.SupportedValidator(validator) {
+		log.Write("[Error] unsupported validator '%s'\n", validator)
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("404 Nothing to see here...")))
 		return
 	}
-	log.Write("[Info] '%s' results for repo '%s/%s'\n", service, user, repo)
+	log.Write("[Info] '%s' results for repo '%s/%s'\n", validator, user, repo)
 
 	srvcfg := config.Read()
-	resdir := filepath.Join(srvcfg.Dir.Result, service, user, repo, srvcfg.Label.ResultsFolder)
+	resdir := filepath.Join(srvcfg.Dir.Result, validator, user, repo, srvcfg.Label.ResultsFolder)
 
 	fp := filepath.Join(resdir, srvcfg.Label.ResultsBadge)
 	badge, err := ioutil.ReadFile(fp)

--- a/web/status.go
+++ b/web/status.go
@@ -17,15 +17,15 @@ import (
 // Status returns the status of the latest BIDS validation for
 // a provided gin user repository.
 func Status(w http.ResponseWriter, r *http.Request) {
-	service := mux.Vars(r)["service"]
-	if !helpers.SupportedValidator(service) {
-		log.Write("[Error] unsupported validator '%s'\n", service)
+	validator := mux.Vars(r)["validator"]
+	if !helpers.SupportedValidator(validator) {
+		log.Write("[Error] unsupported validator '%s'\n", validator)
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("404 Nothing to see here...")))
 		return
 	}
 	user := mux.Vars(r)["user"]
 	repo := mux.Vars(r)["repo"]
-	log.Write("[Info] '%s' status for repo '%s/%s'\n", service, user, repo)
+	log.Write("[Info] '%s' status for repo '%s/%s'\n", validator, user, repo)
 
 	srvcfg := config.Read()
 

--- a/web/validate.go
+++ b/web/validate.go
@@ -423,7 +423,7 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 	}
 	defer deleteSessionKey(gcl)
 
-	statuscode, err := runValidator(repopath, service, commithash, gcl)
+	statuscode, err := runValidator(service, repopath, commithash, gcl)
 	if err != nil {
 		if statuscode == 0 {
 			statuscode = http.StatusInternalServerError

--- a/web/validate.go
+++ b/web/validate.go
@@ -73,7 +73,7 @@ func handleValidationConfig(cfgpath string) (Validationcfg, error) {
 	return valcfg, nil
 }
 
-func runValidator(service, repopath, commit string, gcl *ginclient.Client) (int, error) {
+func runValidator(validator, repopath, commit string, gcl *ginclient.Client) (int, error) {
 	log.Write("[Info] Commit hash: %s", commit)
 
 	repopathparts := strings.SplitN(repopath, "/", 2)
@@ -104,7 +104,7 @@ func runValidator(service, repopath, commit string, gcl *ginclient.Client) (int,
 
 	log.Write("[Info] Found repository on server")
 
-	tmpdir, err := ioutil.TempDir(srvcfg.Dir.Temp, service)
+	tmpdir, err := ioutil.TempDir(srvcfg.Dir.Temp, validator)
 	if err != nil {
 		log.Write("[Error] Internal error: Couldn't create temporary gin directory: %s", err.Error())
 		return http.StatusInternalServerError, fmt.Errorf("validation on %s failed", repopath)
@@ -164,7 +164,7 @@ func runValidator(service, repopath, commit string, gcl *ginclient.Client) (int,
 
 	// Create results folder if necessary
 	// CHECK: can this lead to a race condition, if a job for the same user/repo combination is started twice in short succession?
-	resdir := filepath.Join(srvcfg.Dir.Result, service, repopath, srvcfg.Label.ResultsFolder)
+	resdir := filepath.Join(srvcfg.Dir.Result, validator, repopath, srvcfg.Label.ResultsFolder)
 	err = os.MkdirAll(resdir, os.ModePerm)
 	if err != nil {
 		log.Write("[Error] creating '%s' results folder: %s", repopath, err.Error())
@@ -379,15 +379,15 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 	log.Write("[Info] Commit hash: %s", commithash)
 
 	vars := mux.Vars(r)
-	service := vars["service"]
-	if !helpers.SupportedValidator(service) {
+	validator := vars["validator"]
+	if !helpers.SupportedValidator(validator) {
 		fail(w, http.StatusNotFound, "unsupported validator")
 		return
 	}
 	user := vars["user"]
 	repo := vars["repo"]
 	repopath := fmt.Sprintf("%s/%s", user, repo)
-	log.Write("[Info] '%s' validation for repo '%s'", service, repopath)
+	log.Write("[Info] '%s' validation for repo '%s'", validator, repopath)
 
 	// TODO add check if a repo is currently being validated. Since the cloning
 	// can potentially take quite some time prohibit running the same
@@ -423,7 +423,7 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 	}
 	defer deleteSessionKey(gcl)
 
-	statuscode, err := runValidator(service, repopath, commithash, gcl)
+	statuscode, err := runValidator(validator, repopath, commithash, gcl)
 	if err != nil {
 		if statuscode == 0 {
 			statuscode = http.StatusInternalServerError


### PR DESCRIPTION
*Counterpart to (and depends on) G-Node/gin-cli#214*

The primary reason for this PR is to use the `NewToken()` method that was just added to the gin-cli Client package.

Other, smaller changes included in this PR:
- Bugfix: In  the validation endpoint, the `runValidator()` function was being called with the incorrect argument order.
- Bugfix: The default port wasn't being properly used when an invalid port was specified on the command line.
- The URL that is set for the validator hook uses `url.Path()` to create a valid URL.
- Renamed `service` to `validator` in code.