### PR TITLE
Persistent tokens and hook deletion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: required
 matrix:
   include:
     - go: "1.10.x"
+    - go: "1.11.x"
     - go: tip
   allow_failures:
     - go: tip

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ VOLUME ["/gin-valid/"]
 ENV GINVALIDHOME /gin-valid/
 ENV GIN_CONFIG_DIR /gin-valid/config/client
 
-COPY ./gin-valid /usr/local/bin/.
-
 ENTRYPOINT gin-valid --config=/config/cfg.json
 EXPOSE 3033
+
+COPY ./gin-valid /usr/local/bin/.

--- a/config/config.go
+++ b/config/config.go
@@ -15,9 +15,10 @@ type Directories struct {
 	Temp   string `json:"temp"`
 	Result string `json:"result"`
 	Log    string `json:"log"`
+	Tokens string `json:"tokens"`
 }
 
-// Denotations provide any freuquently used file names or other denotations
+// Denotations provide any frequently used file names or other denotations
 // e.g. validation result files, badge or result folder names.
 type Denotations struct {
 	LogFile              string `json:"logfile"`
@@ -69,6 +70,7 @@ var defaultCfg = ServerCfg{
 		Temp:   filepath.Join(os.Getenv("GINVALIDHOME"), "tmp"),
 		Log:    filepath.Join(os.Getenv("GINVALIDHOME"), "log"),
 		Result: filepath.Join(os.Getenv("GINVALIDHOME"), "results"),
+		Tokens: filepath.Join(os.Getenv("GINVALIDHOME"), "tokens"),
 	},
 	Denotations{
 		LogFile:              "ginvalid.log",

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/login", web.Login)
 	r.HandleFunc("/repos/{user}", web.ListRepos)
 	r.HandleFunc("/repos/{user}/{repo}/{validator}/enable", web.EnableHook)
+	r.HandleFunc("/repos/{user}/{repo}/{hookid}/disable", web.DisableHook)
 	r.HandleFunc("/repos/{user}/{repo}/hooks", web.ShowRepo)
 }
 

--- a/main.go
+++ b/main.go
@@ -100,6 +100,8 @@ func main() {
 		config.Set(srvcfg)
 	}
 
+	// TODO: Create missing directories defined in cfg
+
 	err = log.Init()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[Error] opening logfile '%s'\n", err.Error())

--- a/resources/templates/repolist.go
+++ b/resources/templates/repolist.go
@@ -1,7 +1,7 @@
 package templates
 
 // TODO: Stable access order of Hooks map
-// TODO: Map .ToLower func into this template to lowercase the $key in the URL
+// TODO: Map .ToLower func into this template to lowercase the $hookname in the URL
 const RepoList = `
 	{{ define "content" }}
 	<br/><br/>
@@ -10,9 +10,9 @@ const RepoList = `
 	{{ $repopath := .FullName }}
 	<div><b><a href=/repos/{{ $repopath }}/hooks>{{ $repopath }}</a></b></div>
 	<div><b>Active validators</b>:<br>
-	{{ range $key, $value := .Hooks }}
-		{{ if $value }}
-		{{ $key }}: <a href="/results/{{ $key }}/{{ $repopath }}">results</a><br>
+	{{ range $hookname, $hook := .Hooks }}
+		{{ if eq $hook.State 0 }}
+			{{ $hookname }}: <a href="/results/{{ $hookname }}/{{ $repopath }}">results</a><br>
 		{{ end }}
 	{{ end }}
 	</div>
@@ -23,19 +23,19 @@ const RepoList = `
 	{{ end }}
 `
 
-// TODO: Map .ToLower func into this template to lowercase the $key in the URL
+// TODO: Map .ToLower func into this template to lowercase the $hookname in the URL
 const RepoPage = `
 	{{ define "content" }}
 	<br/><br/>
 	<div>
 	<div><b>{{.FullName}}</b></div>
 	<div><b>Available validators</b>:<br>
-	{{ range $key, $value := .Hooks }}
-		{{ $key }}
-		{{ if $value }}
-		[Enabled] <a href="/repos/{{$.FullName}}/{{ $key }}/disable">disable</a>
+	{{ range $hookname, $hook := .Hooks }}
+		{{ $hookname }}
+		{{ if eq $hook.State 0 }}
+			[Enabled] <a href="/repos/{{$.FullName}}/{{ $hook.ID }}/disable">disable</a>
 		{{ else }}
-		[Disabled] <a href="/repos/{{$.FullName}}/{{ $key }}/enable">enable</a>
+			[Disabled] <a href="/repos/{{$.FullName}}/{{ $hookname }}/enable">enable</a>
 		{{ end }}
 		<br>
 	{{ end }}

--- a/run
+++ b/run
@@ -8,7 +8,7 @@ go build
 docker build --tag=ginvalid .
 
 # copy init server data to live location
-srvdata="/tmp/gin-valid-data-${RANDOM}"
+srvdata="/tmp/gin-valid-data-$(date +'%s')"
 cp -a "./srvdata/." "${srvdata}"
 
 configdir="${srvdata}/config"

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -30,6 +30,7 @@ func EnableHook(w http.ResponseWriter, r *http.Request) {
 	validator := strings.ToLower(vars["validator"])
 	ut, err := getSessionOrRedirect(w, r)
 	if err != nil {
+		log.Write("[Info] %s: Redirecting to login", err.Error())
 		return
 	}
 	if !helpers.SupportedValidator(validator) {
@@ -64,6 +65,7 @@ func DisableHook(w http.ResponseWriter, r *http.Request) {
 
 	ut, err := getSessionOrRedirect(w, r)
 	if err != nil {
+		log.Write("[Info] %s: Redirecting to login", err.Error())
 		return
 	}
 

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -60,14 +60,13 @@ func createValidHook(repopath string, validator string, usertoken gweb.UserToken
 	//   - If it's already hooked, but we don't know about it, check if it's valid and don't recreate
 	log.Write("Adding %s hook to %s\n", validator, repopath)
 
-	gvconfig := config.Read()
+	cfg := config.Read()
 	client := ginclient.New(serveralias)
 	client.UserToken = usertoken
 	hookconfig := make(map[string]string)
-	cfg := config.Read()
 	hooksecret := cfg.Settings.HookSecret
 
-	host := fmt.Sprintf("%s:%s", gvconfig.Settings.RootURL, gvconfig.Settings.Port)
+	host := fmt.Sprintf("%s:%s", cfg.Settings.RootURL, cfg.Settings.Port)
 	u, err := url.Parse(host)
 	u.Path = path.Join(u.Path, "validate", validator, repopath)
 	hookconfig["url"] = u.String()
@@ -90,7 +89,9 @@ func createValidHook(repopath string, validator string, usertoken gweb.UserToken
 		log.Write("[error] non-OK response: %s\n", res.Status)
 		return fmt.Errorf("Hook creation failed: %s", res.Status)
 	}
-	return err
+
+	// link user token to repository name so we can use it for validation
+	return linkToRepo(usertoken.Username, repopath)
 }
 
 func deleteValidHook(repopath string, id int) {

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -102,8 +102,7 @@ func createValidHook(repopath string, validator string, session *usersession) er
 	}
 	// store user's token to disk so that the service can use it to clone the
 	// repository when needed
-	tokenfilename := strings.Replace(repopath, "/", "-", -1)
-	err = saveToken(tokenfilename, session.UserToken)
+	err = saveToken(session.UserToken)
 	return err
 }
 

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -45,7 +45,7 @@ func EnableHook(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, fmt.Sprintf("/repos/%s", ut.Username), http.StatusFound)
 }
 
-func validateHookSecret(data []byte, secret string) bool {
+func checkHookSecret(data []byte, secret string) bool {
 	cfg := config.Read()
 	hooksecret := cfg.Settings.HookSecret
 	sig := hmac.New(sha256.New, []byte(hooksecret))

--- a/web/pkg.go
+++ b/web/pkg.go
@@ -13,7 +13,6 @@ const (
 
 var (
 	sessions = make(map[string]*usersession)
-	hookregs = make(map[string]gweb.UserToken)
 )
 
 type usersession struct {

--- a/web/pkg.go
+++ b/web/pkg.go
@@ -5,17 +5,6 @@ and disabling hooks on the GIN server running the validation.
 */
 package web
 
-import gweb "github.com/G-Node/gin-cli/web"
-
 const (
 	serveralias = "gin"
 )
-
-var (
-	sessions = make(map[string]*usersession)
-)
-
-type usersession struct {
-	sessionID string
-	gweb.UserToken
-}

--- a/web/token.go
+++ b/web/token.go
@@ -9,23 +9,26 @@ import (
 	"github.com/G-Node/gin-valid/config"
 )
 
-func saveToken(filename string, ut gweb.UserToken) error {
+// saveToken writes a token to disk using the username as filename.
+// The location is defined by config.Dir.Tokens.
+func saveToken(ut gweb.UserToken) error {
 	cfg := config.Read()
-	filename = filepath.Join(cfg.Dir.Tokens, filename)
+	filename := filepath.Join(cfg.Dir.Tokens, ut.Username)
 	tokenfile, err := os.Create(filename)
 	defer tokenfile.Close()
 	if err != nil {
 		return err
 	}
 	encoder := gob.NewEncoder(tokenfile)
-	err = encoder.Encode(ut)
-	return err
+	return encoder.Encode(ut)
 }
 
-func loadToken(filename string) (gweb.UserToken, error) {
+// loadToken reads a token from disk using the username as filename.
+// The location is defined by config.Dir.Tokens.
+func loadToken(username string) (gweb.UserToken, error) {
 	cfg := config.Read()
 	ut := gweb.UserToken{}
-	filename = filepath.Join(cfg.Dir.Tokens, filename)
+	filename := filepath.Join(cfg.Dir.Tokens, username)
 	tokenfile, err := os.Open(filename)
 	if err != nil {
 		return ut, err
@@ -34,8 +37,28 @@ func loadToken(filename string) (gweb.UserToken, error) {
 
 	decoder := gob.NewDecoder(tokenfile)
 	err = decoder.Decode(ut)
-	if err != nil {
-		return ut, err
-	}
-	return ut, nil
+	return ut, err
+}
+
+// linkToSession links a sessionID to a user's token.
+func linkToSession(sessionid string, username string) error {
+	return nil
+}
+
+// getTokenBySession loads a user's access token using the session ID found in
+// the user's cookie store.
+func getTokenBySession(sessionid string) (gweb.UserToken, error) {
+	return gweb.UserToken{}, nil
+}
+
+// linkToRepo links a repository name to a user's token.
+// This token will be used for cloning a repository to run a validator when a
+// web hook is triggered.
+func linkToRepo(repopath string, username string) error {
+	return nil
+}
+
+// getTokenByRepo loads a user's access token using a repository path.
+func getTokenByRepo(repopath string) (gweb.UserToken, error) {
+	return gweb.UserToken{}, nil
 }

--- a/web/token.go
+++ b/web/token.go
@@ -41,7 +41,7 @@ func loadToken(username string) (gweb.UserToken, error) {
 }
 
 // linkToSession links a sessionID to a user's token.
-func linkToSession(sessionid string, username string) error {
+func linkToSession(username string, sessionid string) error {
 	return nil
 }
 
@@ -54,7 +54,7 @@ func getTokenBySession(sessionid string) (gweb.UserToken, error) {
 // linkToRepo links a repository name to a user's token.
 // This token will be used for cloning a repository to run a validator when a
 // web hook is triggered.
-func linkToRepo(repopath string, username string) error {
+func linkToRepo(username string, repopath string) error {
 	return nil
 }
 

--- a/web/token.go
+++ b/web/token.go
@@ -25,9 +25,9 @@ func saveToken(ut gweb.UserToken) error {
 	return encoder.Encode(ut)
 }
 
-// loadUserToken reads a token from disk using the username as filename.
+// getTokenByUsername reads a token from disk using the username as filename.
 // The location is defined by config.Dir.Tokens.
-func loadUserToken(username string) (gweb.UserToken, error) {
+func getTokenByUsername(username string) (gweb.UserToken, error) {
 	cfg := config.Read()
 	filename := filepath.Join(cfg.Dir.Tokens, username)
 	return loadToken(filename)

--- a/web/token.go
+++ b/web/token.go
@@ -1,0 +1,41 @@
+package web
+
+import (
+	"encoding/gob"
+	"os"
+	"path/filepath"
+
+	gweb "github.com/G-Node/gin-cli/web"
+	"github.com/G-Node/gin-valid/config"
+)
+
+func saveToken(filename string, ut gweb.UserToken) error {
+	cfg := config.Read()
+	filename = filepath.Join(cfg.Dir.Tokens, filename)
+	tokenfile, err := os.Create(filename)
+	defer tokenfile.Close()
+	if err != nil {
+		return err
+	}
+	encoder := gob.NewEncoder(tokenfile)
+	err = encoder.Encode(ut)
+	return err
+}
+
+func loadToken(filename string) (gweb.UserToken, error) {
+	cfg := config.Read()
+	ut := gweb.UserToken{}
+	filename = filepath.Join(cfg.Dir.Tokens, filename)
+	tokenfile, err := os.Open(filename)
+	if err != nil {
+		return ut, err
+	}
+	defer tokenfile.Close()
+
+	decoder := gob.NewDecoder(tokenfile)
+	err = decoder.Decode(ut)
+	if err != nil {
+		return ut, err
+	}
+	return ut, nil
+}

--- a/web/token.go
+++ b/web/token.go
@@ -54,7 +54,7 @@ func linkToSession(username string, sessionid string) error {
 	tokendir := cfg.Dir.Tokens
 	utfile := filepath.Join(tokendir, username)
 	sidfile := filepath.Join(tokendir, "by-sessionid", b32(sessionid))
-	return os.Link(utfile, sidfile)
+	return os.Symlink(utfile, sidfile)
 }
 
 // getTokenBySession loads a user's access token using the session ID found in
@@ -74,7 +74,7 @@ func linkToRepo(username string, repopath string) error {
 	tokendir := cfg.Dir.Tokens
 	utfile := filepath.Join(tokendir, username)
 	sidfile := filepath.Join(tokendir, "by-repo", b32(repopath))
-	return os.Link(utfile, sidfile)
+	return os.Symlink(utfile, sidfile)
 }
 
 // getTokenByRepo loads a user's access token using a repository path.

--- a/web/token.go
+++ b/web/token.go
@@ -85,6 +85,15 @@ func getTokenByRepo(repopath string) (gweb.UserToken, error) {
 	return loadToken(filename)
 }
 
+// rmTokenRepoLink deletes a repository -> token link, removing our ability to
+// clone the repository.
+func rmTokenRepoLink(repopath string) error {
+	cfg := config.Read()
+	tokendir := cfg.Dir.Tokens
+	filename := filepath.Join(tokendir, "by-repo", b32(repopath))
+	return os.Remove(filename)
+}
+
 // b32 encodes a string to base 32. Use this to make strings such as IDs or
 // repopaths filename friendly.
 func b32(s string) string {

--- a/web/user.go
+++ b/web/user.go
@@ -99,6 +99,11 @@ func doLogin(username, password string) (string, error) {
 		log.Write("Login successful. Username: %s", username)
 	}
 
+	err = saveToken(gincl.UserToken)
+	if err != nil {
+		return "", err
+	}
+
 	sessionid, err := generateNewSessionID()
 	if err != nil {
 		return "", err

--- a/web/user.go
+++ b/web/user.go
@@ -3,7 +3,6 @@ package web
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -79,37 +78,6 @@ func doLogin(username, password string) (*usersession, error) {
 		return nil, err
 	}
 	return &usersession{sessionid, gincl.UserToken}, nil
-}
-
-func saveToken(filename string, ut gweb.UserToken) error {
-	cfg := config.Read()
-	filename = filepath.Join(cfg.Dir.Tokens, filename)
-	tokenfile, err := os.Create(filename)
-	defer tokenfile.Close()
-	if err != nil {
-		return err
-	}
-	encoder := gob.NewEncoder(tokenfile)
-	err = encoder.Encode(ut)
-	return err
-}
-
-func loadToken(filename string) (gweb.UserToken, error) {
-	cfg := config.Read()
-	ut := gweb.UserToken{}
-	filename = filepath.Join(cfg.Dir.Tokens, filename)
-	tokenfile, err := os.Open(filename)
-	if err != nil {
-		return ut, err
-	}
-	defer tokenfile.Close()
-
-	decoder := gob.NewDecoder(tokenfile)
-	err = decoder.Decode(ut)
-	if err != nil {
-		return ut, err
-	}
-	return ut, nil
 }
 
 // Login renders the login form and logs in the user to the GIN server, storing

--- a/web/user.go
+++ b/web/user.go
@@ -161,9 +161,9 @@ func getSessionOrRedirect(w http.ResponseWriter, r *http.Request) (gweb.UserToke
 		return gweb.UserToken{}, fmt.Errorf("No session cookie found")
 	}
 	usertoken, err := getTokenBySession(cookie.Value)
-
 	if err != nil {
 		http.Redirect(w, r, "/login", http.StatusFound)
+		log.Write("[Error] Loading token failed: %s", err.Error())
 		return gweb.UserToken{}, fmt.Errorf("Invalid session found in cookie")
 	}
 	return usertoken, nil
@@ -179,6 +179,7 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 
 	ut, err := getSessionOrRedirect(w, r)
 	if err != nil {
+		log.Write("[Info] %s: Redirecting to login", err.Error())
 		return
 	}
 

--- a/web/user.go
+++ b/web/user.go
@@ -348,6 +348,7 @@ func ShowRepo(w http.ResponseWriter, r *http.Request) {
 
 	ut, err := getSessionOrRedirect(w, r)
 	if err != nil {
+		log.Write("[Info] %s: Redirecting to login", err.Error())
 		return
 	}
 

--- a/web/validate.go
+++ b/web/validate.go
@@ -399,10 +399,11 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 	// TODO: Use the payload data to check if the specific commit has already
 	// been validated
 
-	// get the username + token from the registered hooks map
+	// get the token from the file stored in tokens directory
 
-	ut, ok := hookregs[repopath]
-	if !ok {
+	tokenfilename := strings.Replace(repopath, "/", "-", -1)
+	ut, err := loadToken(tokenfilename)
+	if err != nil {
 		// We don't have a valid token for this repository: can't clone
 		msg := fmt.Sprintf("accessing '%s': no access token found", repopath)
 		fail(w, http.StatusUnauthorized, msg)

--- a/web/validate.go
+++ b/web/validate.go
@@ -367,7 +367,7 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("bad request"))
 		return
 	}
-	if !validateHookSecret(b, secret) {
+	if !checkHookSecret(b, secret) {
 		log.Write("[Error] authorisation failed: bad secret")
 		fail(w, http.StatusBadRequest, "bad request")
 		return

--- a/web/validate.go
+++ b/web/validate.go
@@ -399,10 +399,8 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 	// TODO: Use the payload data to check if the specific commit has already
 	// been validated
 
-	// get the token from the file stored in tokens directory
-
-	tokenfilename := strings.Replace(repopath, "/", "-", -1)
-	ut, err := loadToken(tokenfilename)
+	// get the token for this repository
+	ut, err := getTokenByRepo(repopath)
 	if err != nil {
 		// We don't have a valid token for this repository: can't clone
 		msg := fmt.Sprintf("accessing '%s': no access token found", repopath)


### PR DESCRIPTION
This PR introduces persistent tokens and user sessions and adds support for removing hooks from GIN repositories.

## Hook deletion
Some changes to the page templates were made to support hook deletion.
A new enum is introduced to support hooks in multiple states (e.g., a hook exists but it is disabled, or misconfigured). The plan is to be able to inform the user of a bad configuration and offer to fix it.

## Persistent tokens and session IDs
The session persistence uses token files stored as Go gobs (the same format used by gin-cli). The session storage and repository cloning works using the following strategy:
- On user login, a gin-valid token is created or an existing gin-valid token is requested from the server and stored in a directory specified in the server configuration file.
    - The username is used as the name for the file.
- A session ID is created for the user and stored in a cookie. Each session ID is mapped to a user token. This is achieved by symlinking the user's session ID to their token on disk, in the token directory, in a subdirectory called `by-sessionid`.
    - The result of this is that when a user returns with a valid cookie, any request they make that involves communicating with the GIN server (e.g., listing repositories, enabling hooks) loads their token using the session ID.
- When the user creates a hook, another symlink is created, this time linking the repository name to the user's token, in a subdirectory called `by-repo`.
    - The result of this is that when a repository hook is triggered, the cloning of the repository is achieved by loading the user's token using the repository name.

Both the session ID and the repository name are base32 encoded when linking to make the filesystem friendly (ASCII).