### PR TITLE
Page redirects

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,14 +39,15 @@ func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/pubvalidate", web.PubValidateGet).Methods("GET")
 	r.HandleFunc("/pubvalidate", web.PubValidatePost).Methods("POST")
 	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate).Methods("POST")
-	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status)
-	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results)
-	r.HandleFunc("/login", web.Login)
-	r.HandleFunc("/repos", web.ListRepos)
-	r.HandleFunc("/repos/{user}", web.ListRepos)
-	r.HandleFunc("/repos/{user}/{repo}/{validator}/enable", web.EnableHook)
-	r.HandleFunc("/repos/{user}/{repo}/{hookid}/disable", web.DisableHook)
-	r.HandleFunc("/repos/{user}/{repo}/hooks", web.ShowRepo)
+	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status).Methods("GET")
+	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results).Methods("GET")
+	r.HandleFunc("/login", web.LoginGet).Methods("GET")
+	r.HandleFunc("/login", web.LoginPost).Methods("POST")
+	r.HandleFunc("/repos", web.ListRepos).Methods("GET")
+	r.HandleFunc("/repos/{user}", web.ListRepos).Methods("GET")
+	r.HandleFunc("/repos/{user}/{repo}/{validator}/enable", web.EnableHook).Methods("GET")
+	r.HandleFunc("/repos/{user}/{repo}/{hookid}/disable", web.DisableHook).Methods("GET")
+	r.HandleFunc("/repos/{user}/{repo}/hooks", web.ShowRepo).Methods("GET")
 }
 
 func startupCheck(srvcfg config.ServerCfg) {

--- a/main.go
+++ b/main.go
@@ -36,7 +36,8 @@ Options:
 func registerRoutes(r *mux.Router) {
 	r.StrictSlash(true)
 	r.HandleFunc("/", web.Root)
-	r.HandleFunc("/pubvalidate", web.PubValidate)
+	r.HandleFunc("/pubvalidate", web.PubValidateGet).Methods("GET")
+	r.HandleFunc("/pubvalidate", web.PubValidatePost).Methods("POST")
 	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate)
 	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status)
 	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ Options:
   `
 
 func registerRoutes(r *mux.Router) {
+	r.StrictSlash(true)
 	r.HandleFunc("/", web.Root)
 	r.HandleFunc("/pubvalidate", web.PubValidate)
 	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status)
 	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results)
 	r.HandleFunc("/login", web.Login)
+	r.HandleFunc("/repos", web.ListRepos)
 	r.HandleFunc("/repos/{user}", web.ListRepos)
 	r.HandleFunc("/repos/{user}/{repo}/{validator}/enable", web.EnableHook)
 	r.HandleFunc("/repos/{user}/{repo}/{hookid}/disable", web.DisableHook)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/", web.Root)
 	r.HandleFunc("/pubvalidate", web.PubValidateGet).Methods("GET")
 	r.HandleFunc("/pubvalidate", web.PubValidatePost).Methods("POST")
-	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate)
+	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate).Methods("POST")
 	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status)
 	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results)
 	r.HandleFunc("/login", web.Login)

--- a/resources/templates/layout.go
+++ b/resources/templates/layout.go
@@ -1,5 +1,9 @@
 package templates
 
+// TODO: Switch Login || Logout
+
+// Layout is the main site template. It includes the header and footer and
+// embeds the content for every other page.
 var Layout = `
 {{ define "layout" }}
 <!DOCTYPE html>
@@ -22,7 +26,10 @@ var Layout = `
                         <a class="item brand" href="https://gin.g-node.org/">
                             <img class="ui mini image" src="https://gin.g-node.org/img/favicon.png">
                         </a>
-                        <a class="item" href="https://gin.g-node.org/">Back to gin</a>
+                        <a class="item" href="https://gin.g-node.org/">Back to GIN</a>
+                        <a class="item" href="/repos">Repositories</a>
+                        <a class="item" href="/pubvalidate">One-time validation</a>
+                        <a class="item" href="/login">Login</a>
                     </div>
                 </div>
             </div>
@@ -48,7 +55,7 @@ var Layout = `
                             <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/imprint" target="_blank">Imprint</a>
                             <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/contact" target="_blank">Contact</a>
                             <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/Terms+of+Use" target="_blank">Terms of Use</a>
-    
+
                             <div class="ui supersmall">
                                 Hosted by:
                                 <img class="ui bmbf image" src="https://web.gin.g-node.org/img/lmu.png"/>

--- a/resources/templates/pubvalidate.go
+++ b/resources/templates/pubvalidate.go
@@ -8,7 +8,7 @@ var PubValidate = `
 Enter the full name of a GIN repository (user/repository) below and select a validator to run:
 <div>
     <form action="/pubvalidate" method="post">
-    <p>Repository name: <input type="text" name="repopath"></p>
+    <p>Repository name: <input type="text" name="repopath"> <input type="submit" value="BIDS"></p>
     </form>
 </div>
 

--- a/resources/templates/pubvalidate.go
+++ b/resources/templates/pubvalidate.go
@@ -1,0 +1,19 @@
+package templates
+
+var PubValidate = `
+{{ define "content" }}
+
+<br><br>
+<hr>
+Enter the full name of a GIN repository (user/repository) below and select a validator to run:
+<div>
+    <form action="/pubvalidate" method="post">
+    <p>Repository name: <input type="text" name="repopath"></p>
+    </form>
+</div>
+
+<hr>
+Alternatively, you can <a href="/login">login</a> using your GIN account to set up automatic validation of your public and private repositories.
+
+{{ end }}
+`

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -20,10 +20,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// EnableHook creates a new hook on the server for the specific repository.
 func EnableHook(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		return
-	}
 	vars := mux.Vars(r)
 	user := vars["user"]
 	repo := vars["repo"]
@@ -47,10 +45,8 @@ func EnableHook(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, fmt.Sprintf("/repos/%s", ut.Username), http.StatusFound)
 }
 
+// DisableHook removes a hook from the server.
 func DisableHook(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		return
-	}
 	vars := mux.Vars(r)
 	user := vars["user"]
 	repo := vars["repo"]

--- a/web/user.go
+++ b/web/user.go
@@ -205,7 +205,13 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vars := mux.Vars(r)
-	user := vars["user"]
+	user, ok := vars["user"]
+	if !ok {
+		// redirect to logged in user
+		user = ut.Username
+		http.Redirect(w, r, fmt.Sprintf("/repos/%s", user), http.StatusFound)
+		return
+	}
 	cl := ginclient.New(serveralias)
 	cl.UserToken = ut
 

--- a/web/user.go
+++ b/web/user.go
@@ -130,48 +130,48 @@ func doLogin(username, password string) (string, error) {
 	return sessionid, err
 }
 
-// Login renders the login form and logs in the user to the GIN server, storing
-// a session token.
-func Login(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet {
-		log.Write("Login page")
-		tmpl := template.New("layout")
-		tmpl, err := tmpl.Parse(templates.Layout)
-		if err != nil {
-			log.Write("[Error] failed to parse html layout page")
-			fail(w, http.StatusInternalServerError, "something went wrong")
-			return
-		}
-		tmpl, err = tmpl.Parse(templates.Login)
-		if err != nil {
-			log.Write("[Error] failed to render login page")
-			fail(w, http.StatusInternalServerError, "something went wrong")
-			return
-		}
-		tmpl.Execute(w, nil)
-	} else if r.Method == http.MethodPost {
-		log.Write("Doing login")
-		r.ParseForm()
-		username := r.Form["username"][0]
-		password := r.Form["password"][0]
-		sessionid, err := doLogin(username, password)
-		if err != nil {
-			log.Write("[error] Login failed: %s", err.Error())
-			fail(w, http.StatusUnauthorized, "authentication failed")
-			return
-		}
-
-		cfg := config.Read()
-		cookie := http.Cookie{
-			Name:    cfg.Settings.CookieName,
-			Value:   sessionid,
-			Expires: cookieExp(),
-			Secure:  false, // TODO: Switch when we go live
-		}
-		http.SetCookie(w, &cookie)
-		// Redirect to repo listing
-		http.Redirect(w, r, fmt.Sprintf("/repos/%s", username), http.StatusFound)
+// LoginGet renders the login form
+func LoginGet(w http.ResponseWriter, r *http.Request) {
+	log.Write("Login page")
+	tmpl := template.New("layout")
+	tmpl, err := tmpl.Parse(templates.Layout)
+	if err != nil {
+		log.Write("[Error] failed to parse html layout page")
+		fail(w, http.StatusInternalServerError, "something went wrong")
+		return
 	}
+	tmpl, err = tmpl.Parse(templates.Login)
+	if err != nil {
+		log.Write("[Error] failed to render login page")
+		fail(w, http.StatusInternalServerError, "something went wrong")
+		return
+	}
+	tmpl.Execute(w, nil)
+}
+
+// LoginPost logs in the user to the GIN server, storing a session token.
+func LoginPost(w http.ResponseWriter, r *http.Request) {
+	log.Write("Doing login")
+	r.ParseForm()
+	username := r.Form["username"][0]
+	password := r.Form["password"][0]
+	sessionid, err := doLogin(username, password)
+	if err != nil {
+		log.Write("[error] Login failed: %s", err.Error())
+		fail(w, http.StatusUnauthorized, "authentication failed")
+		return
+	}
+
+	cfg := config.Read()
+	cookie := http.Cookie{
+		Name:    cfg.Settings.CookieName,
+		Value:   sessionid,
+		Expires: cookieExp(),
+		Secure:  false, // TODO: Switch when we go live
+	}
+	http.SetCookie(w, &cookie)
+	// Redirect to repo listing
+	http.Redirect(w, r, fmt.Sprintf("/repos/%s", username), http.StatusFound)
 }
 
 func getSessionOrRedirect(w http.ResponseWriter, r *http.Request) (gweb.UserToken, error) {
@@ -194,10 +194,6 @@ func getSessionOrRedirect(w http.ResponseWriter, r *http.Request) (gweb.UserToke
 // accessible) by a given user and renders the page which displays the
 // repositories and their validation status.
 func ListRepos(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		return
-	}
-
 	ut, err := getSessionOrRedirect(w, r)
 	if err != nil {
 		log.Write("[Info] %s: Redirecting to login", err.Error())
@@ -348,10 +344,6 @@ func getRepoHooks(cl *ginclient.Client, repopath string) (map[string]ginhook, er
 // ShowRepo renders the repository information page where the user can enable or
 // disable validator hooks.
 func ShowRepo(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		return
-	}
-
 	ut, err := getSessionOrRedirect(w, r)
 	if err != nil {
 		log.Write("[Info] %s: Redirecting to login", err.Error())

--- a/web/validate.go
+++ b/web/validate.go
@@ -346,13 +346,6 @@ func PubValidatePost(w http.ResponseWriter, r *http.Request) {
 // Any cloned files are cleaned up after the check is done.
 func Validate(w http.ResponseWriter, r *http.Request) {
 	// TODO: Simplify/split this function
-	if r.Method != http.MethodPost {
-		// Do nothing
-		log.Write("[Error] no post request: %s", r.Method)
-		// TODO: Redirect to results
-		return
-	}
-
 	secret := r.Header.Get("X-Gogs-Signature")
 
 	var hookdata gogs.PushPayload

--- a/web/validate.go
+++ b/web/validate.go
@@ -271,22 +271,20 @@ func Root(w http.ResponseWriter, r *http.Request) {
 // to manually run a validator on a publicly accessible repository, without
 // using a web hook.
 func PubValidateGet(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet {
-		tmpl := template.New("layout")
-		tmpl, err := tmpl.Parse(templates.Layout)
-		if err != nil {
-			log.Write("[Error] failed to parse html layout page")
-			fail(w, http.StatusInternalServerError, "something went wrong")
-			return
-		}
-		tmpl, err = tmpl.Parse(templates.PubValidate)
-		if err != nil {
-			log.Write("[Error] failed to render root page")
-			fail(w, http.StatusInternalServerError, "something went wrong")
-			return
-		}
-		tmpl.Execute(w, nil)
+	tmpl := template.New("layout")
+	tmpl, err := tmpl.Parse(templates.Layout)
+	if err != nil {
+		log.Write("[Error] failed to parse html layout page")
+		fail(w, http.StatusInternalServerError, "something went wrong")
+		return
 	}
+	tmpl, err = tmpl.Parse(templates.PubValidate)
+	if err != nil {
+		log.Write("[Error] failed to render root page")
+		fail(w, http.StatusInternalServerError, "something went wrong")
+		return
+	}
+	tmpl.Execute(w, nil)
 }
 
 // PubValidatePost parses the POST data from the root form and calls the


### PR DESCRIPTION
*Was going to add some more planned changes but let's keep it short.*

Adding some redirects and tweaking the layout a bit:
- Links in header: Repositories (user's repo listing), One-time validation (manual validation trigger form), Login (in a future PR will change to Logout when logged in).
- Navigating to /repos redirects to /repos/user if logged in (otherwise redirects to login page).
- Root URL redirects to /repos (and then to login or repo listing accordingly).
- Limited some routes based on method (POST or GET).