### PR TITLE
Fix changed gin-cli log init

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	srvcfg := config.Read()
 
 	// Parse commandline arguments
-	args, err := docopt.ParseArgs(usage, nil, "v1.0.0")
+	args, err := docopt.ParseArgs(usage, nil, "v1.0.1")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n[Error] parsing cli arguments: '%s', abort...\n\n", err.Error())
 		os.Exit(-1)

--- a/web/user.go
+++ b/web/user.go
@@ -81,7 +81,7 @@ func generateNewSessionID() (string, error) {
 
 func doLogin(username, password string) (string, error) {
 	gincl := ginclient.New(serveralias)
-	glog.Init("")
+	glog.Init()
 	cfg := config.Read()
 	clientID := cfg.Settings.ClientID
 

--- a/web/validate.go
+++ b/web/validate.go
@@ -123,7 +123,7 @@ func runValidator(validator, repopath, commit string, gcl *ginclient.Client) (in
 	// efficient by only downloading the content in the directories which are
 	// specified in the validator config (if it exists).
 
-	glog.Init("")
+	glog.Init()
 	clonechan := make(chan git.RepoFileStatus)
 	os.Chdir(tmpdir)
 	go gcl.CloneRepo(repopath, clonechan)


### PR DESCRIPTION
The gin-cli logger changed its init signature, this PR draws level with the changes and updates the version number.