### PR TITLE
Redesign templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN go version
 COPY ./go.mod ./go.sum /gin-valid/
 WORKDIR /gin-valid
 
-# download deps before bringing in the main package
+# download deps before bringing in the sources
 RUN go mod download
 COPY ./cmd /gin-valid/cmd/
 COPY ./internal /gin-valid/internal/
@@ -52,15 +52,12 @@ RUN mkdir -p /gin-valid/config
 RUN mkdir -p /gin-valid/tokens/by-sessionid
 RUN mkdir -p /gin-valid/tokens/by-repo
 
-VOLUME ["/gin-valid/"]
-
 ENV GINVALIDHOME /gin-valid/
+WORKDIR /gin-valid
 ENV GIN_CONFIG_DIR /gin-valid/config/client
-
-ENV GOPATH /go
 
 # Copy binary and resources into runner image
 COPY --from=binbuilder /gin-valid/ginvalid /
 
-ENTRYPOINT ./ginvalid --config=/gin-valid/config/cfg.json
+ENTRYPOINT /ginvalid --config=/gin-valid/config/cfg.json
 EXPOSE 3033

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ type Denotations struct {
 	ValidationConfigFile string `json:"valcfgfile"`
 }
 
+type GINAddresses struct {
+	WebURL string `json:"weburl"`
+	GitURL string `json:"giturl"`
+}
+
 // Settings provide the default server settings.
 // "Validators" currently only supports "BIDS".
 type Settings struct {
@@ -45,10 +50,11 @@ type Settings struct {
 // ServerCfg holds the config used to setup the gin validation server and
 // the paths to all required executables, temporary and permanent folders.
 type ServerCfg struct {
-	Settings Settings    `json:"settings"`
-	Exec     Executables `json:"executables"`
-	Dir      Directories `json:"directories"`
-	Label    Denotations `json:"denotations"`
+	Settings     Settings     `json:"settings"`
+	Exec         Executables  `json:"executables"`
+	Dir          Directories  `json:"directories"`
+	Label        Denotations  `json:"denotations"`
+	GINAddresses GINAddresses `json:"ginaddresses"`
 }
 
 var defaultCfg = ServerCfg{
@@ -78,6 +84,10 @@ var defaultCfg = ServerCfg{
 		ResultsFile:          "results.json",
 		ResultsBadge:         "results.svg",
 		ValidationConfigFile: "ginvalidation.yaml",
+	},
+	GINAddresses{
+		WebURL: "https://gin.g-node.org:443",
+		GitURL: "git@gin.g-node.org:22",
 	},
 }
 

--- a/internal/resources/templates/layout.go
+++ b/internal/resources/templates/layout.go
@@ -14,7 +14,7 @@ var Layout = `
 		<link rel="stylesheet" href="https://gin.g-node.org/assets/octicons-4.3.0/octicons.min.css">
 		<link rel="stylesheet" href="https://gin.g-node.org/css/semantic-2.3.1.min.css">
 		<link rel="stylesheet" href="https://gin.g-node.org/css/gogs.css?v=921e73e55b4d707a9a72151df987dce1">
-		<title>Sign In - GIN Valid</title>
+		<title>GIN Valid</title>
 		<link rel="stylesheet" href="https://gin.g-node.org/css/custom.css">
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:site" content="@gnode" />

--- a/internal/resources/templates/layout.go
+++ b/internal/resources/templates/layout.go
@@ -6,71 +6,63 @@ package templates
 // embeds the content for every other page.
 var Layout = `
 {{ define "layout" }}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://web.gin.g-node.org/css/semantic-2.2.10.min.css">
-    <link rel="stylesheet" href="https://web.gin.g-node.org/css/gogs.css">
-    <title>G-Node GIN BIDS validation</title>
-</head>
-<body>
-    <div class="following bar light">
-        <div class="ui container">
-            <div class="ui grid">
-                <div class="column">
-                    <div class="ui top secondary menu">
-                        <a class="item brand" href="https://gin.g-node.org/">
-                            <img class="ui mini image" src="https://gin.g-node.org/img/favicon.png">
-                        </a>
-                        <a class="item" href="https://gin.g-node.org/">Back to GIN</a>
-                        <a class="item" href="/repos">Repositories</a>
-                        <a class="item" href="/pubvalidate">One-time validation</a>
-                        <a class="item" href="/login">Login</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="ui stackable middle very relaxed page grid">
-        <div class="container main-container plainbox">
-            {{ template "content" . }}
-        </div>
-    </div>
-    <footer>
-        <div class="following bar light">
-            <div class="ui container">
-                <div class="ui grid">
-                    <div class="column">
-                        <div class="ui top secondary menu center">
-                            <a class="item brand" href="http://www.g-node.org">
-                                <img class="ui mini image"
-                                     src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>
-                                © G-Node, 2018
-                            </a>
-                            <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/about" target="_blank">About</a>
-                            <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/imprint" target="_blank">Imprint</a>
-                            <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/contact" target="_blank">Contact</a>
-                            <a class="item brand" href="https://web.gin.g-node.org/G-Node/Info/wiki/Terms+of+Use" target="_blank">Terms of Use</a>
-
-                            <div class="ui supersmall">
-                                Hosted by:
-                                <img class="ui bmbf image" src="https://web.gin.g-node.org/img/lmu.png"/>
-                            </div>
-                            <div class="ui supersmall">
-                                Funded by:
-                                <img class="ui bmbf image" src="https://web.gin.g-node.org/img/bmbf.png"/>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </footer>
-</body>
+<html>
+	<!DOCTYPE html>
+	<head data-suburl="">
+		<link rel="shortcut icon" href="https://gin.g-node.org/img/favicon.png" />
+		<link rel="stylesheet" href="https://gin.g-node.org/assets/font-awesome-4.6.3/css/font-awesome.min.css">
+		<link rel="stylesheet" href="https://gin.g-node.org/assets/octicons-4.3.0/octicons.min.css">
+		<link rel="stylesheet" href="https://gin.g-node.org/css/semantic-2.3.1.min.css">
+		<link rel="stylesheet" href="https://gin.g-node.org/css/gogs.css?v=921e73e55b4d707a9a72151df987dce1">
+		<title>Sign In - GIN Valid</title>
+		<link rel="stylesheet" href="https://gin.g-node.org/css/custom.css">
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:site" content="@gnode" />
+		<meta name="twitter:title" content="GIN Valid"/>
+		<meta name="twitter:description" content="G-Node GIN Validation service"/>
+		<meta name="twitter:image" content="https://gin.g-node.org/img/favicon.png" />
+	</head>
+	<body>
+		<div class="full height">
+			<div class="following bar light">
+				<div class="ui container">
+					<div class="ui grid">
+						<div class="column">
+							<div class="ui top secondary menu">
+								<a class="item brand" href="https://gin.g-node.org/">
+									<img class="ui mini image" src="https://gin.g-node.org/img/favicon.png">
+								</a>
+								<a class="item" href="https://gin.g-node.org/">Back to GIN</a>
+								<a class="item" href="/repos">Repositories</a>
+								<a class="item" href="/pubvalidate">One-time validation</a>
+								<a class="item" href="/login">Login</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			{{ template "content" . }}
+		</div>
+		<footer>
+			<div class="ui container">
+				<div class="ui center links item brand footertext">
+					<a href="http://www.g-node.org"><img class="ui mini footericon" src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>© G-Node, 2016-2019</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/about">About</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/imprint">Imprint</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/contact">Contact</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/Terms+of+Use">Terms of Use</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/Datenschutz">Datenschutz</a>
+				</div>
+				<div class="ui center links item brand footertext">
+					<span>Powered by:      <a href="https://github.com/gogits/gogs"><img class="ui mini footericon" src="https://gin.g-node.org/img/gogs.svg"/></a>         </span>
+					<span>Hosted by:       <a href="http://neuro.bio.lmu.de"><img class="ui mini footericon" src="https://gin.g-node.org/img/lmu.png"/></a>          </span>
+					<span>Funded by:       <a href="http://www.bmbf.de"><img class="ui mini footericon" src="https://gin.g-node.org/img/bmbf.png"/></a>         </span>
+					<span>Registered with: <a href="http://doi.org/10.17616/R3SX9N"><img class="ui mini footericon" src="https://gin.g-node.org/img/re3.png"/></a>          </span>
+					<span>Recommended by:  <a href="https://www.nature.com/sdata/policies/repositories#neurosci"><img class="ui mini footericon" src="https://gin.g-node.org/img/sdatarecbadge.jpg"/><a href="https://journals.plos.org/plosone/s/data-availability#loc-neuroscience"><img class="ui mini footericon" src="https://gin.g-node.org/img/sm_plos-logo-sm.png"/></a></span>
+				</div>
+			</div>
+		</footer>
+	</body>
 </html>
 {{ end }}
 `

--- a/internal/resources/templates/login.go
+++ b/internal/resources/templates/login.go
@@ -3,17 +3,31 @@ package templates
 // TODO: add csrf thingie
 var Login = `
 {{ define "content" }}
-
-Please log in using your GIN credentials
-<hr>
-<div>
-    <form action="/login" method="post">
-        <p>Username: <input type="text" name="username"></p>
-        <p>Password: <input type="password" name="password"></p>
-        <input type="submit" value="Submit">
-    </form>
-</div>
-
-
+			<div class="user signin">
+				<div class="ui middle very relaxed page grid">
+					<div class="column">
+						<form class="ui form" action="/login" method="post">
+							<input type="hidden" name="_csrf" value="">
+							<h3 class="ui top attached header">
+								Sign In using your GIN credentials
+							</h3>
+							<div class="ui attached segment">
+								<div class="required inline field ">
+									<label for="username">Username or email</label>
+									<input id="username" name="username" value="" autofocus required>
+								</div>
+								<div class="required inline field ">
+									<label for="password">Password</label>
+									<input id="password" name="password" type="password" autocomplete="off" value="" required>
+								</div>
+								<div class="inline field">
+									<label></label>
+									<button class="ui green button">Sign In</button>
+								</div>
+							</div>
+						</form>
+					</div>
+				</div>
+			</div>
 {{ end }}
 `

--- a/internal/resources/templates/repolist.go
+++ b/internal/resources/templates/repolist.go
@@ -1,7 +1,6 @@
 package templates
 
 // TODO: Stable access order of Hooks map
-// TODO: Map .ToLower func into this template to lowercase the $hookname in the URL
 const RepoList = `
 	{{ define "content" }}
 	<br/><br/>

--- a/internal/resources/templates/repolist.go
+++ b/internal/resources/templates/repolist.go
@@ -2,45 +2,59 @@ package templates
 
 // TODO: Stable access order of Hooks map
 const RepoList = `
-	{{ define "content" }}
-	<br/><br/>
-	<div>
-	{{ range . }}
-	{{ $repopath := .FullName }}
-	<div><b><a href=/repos/{{ $repopath }}/hooks>{{ $repopath }}</a></b></div>
-	<div><b>Active validators</b>:<br>
-	{{ range $hookname, $hook := .Hooks }}
-		{{ if eq $hook.State 0 }}
-			{{ $hookname }}: <a href="/results/{{ $hookname }}/{{ $repopath }}">results</a><br>
-		{{ end }}
-	{{ end }}
+{{define "content"}}
+
+<div class="explore repositories">
+	<div class="ui container repository list">
+		{{range .}}
+			{{$repopath := .FullName}}
+			<div class="item">
+				<div class="ui grid">
+					<div class="ui two wide column middle aligned center">
+						<i class="mega-octicon octicon-repo"></i>
+					</div>
+					<div class="ui fourteen wide column">
+						<div class="ui header">
+							<a class="name" href="/repos/{{$repopath}}/hooks">{{$repopath}}</a>
+							<div class="ui links text normal small">
+								<span>Active validators</span>
+						{{range $hookname, $hook := .Hooks}}
+							{{if eq $hook.State 0}}
+								<span> | {{$hookname | ToUpper}}: <a href="/results/{{$hookname | ToLower}}/{{$repopath}}">results</a> </span>
+							{{end}}
+						{{end}}
+							</div>
+						</div>
+						<p class="has-emoji">{{.Description}}</p>
+						<a href="{{.HTMLURL}}">Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">Repository hooks</a>
+					</div>
+				</div>
+			</div>
+		{{end}}
 	</div>
-	<div>{{.Description}} {{.Website}}</div>
-	<hr>
-	{{ end }}
-	</div>
-	{{ end }}
+</div>
+	{{end}}
 `
 
 // TODO: Map .ToLower func into this template to lowercase the $hookname in the URL
 const RepoPage = `
-	{{ define "content" }}
+{{ define "content" }}
 	<br/><br/>
 	<div>
-	<div><b>{{.FullName}}</b></div>
-	<div><b>Available validators</b>:<br>
-	{{ range $hookname, $hook := .Hooks }}
-		{{ $hookname }}
-		{{ if eq $hook.State 0 }}
-			[Enabled] <a href="/repos/{{$.FullName}}/{{ $hook.ID }}/disable">disable</a>
-		{{ else }}
-			[Disabled] <a href="/repos/{{$.FullName}}/{{ $hookname }}/enable">enable</a>
-		{{ end }}
-		<br>
-	{{ end }}
+		<div><b>{{.FullName}}</b></div>
+		<div><b>Available validators</b>:<br>
+		{{ range $hookname, $hook := .Hooks }}
+			{{ $hookname }}
+			{{ if eq $hook.State 0 }}
+				[Enabled] <a href="/repos/{{$.FullName}}/{{ $hook.ID }}/disable">disable</a>
+			{{ else }}
+					[Disabled] <a href="/repos/{{$.FullName}}/{{ $hookname }}/enable">enable</a>
+			{{ end }}
+				<br>
+			{{ end }}
+		</div>
+		<div>{{.Description}} {{.Website}}</div>
+		<hr>
 	</div>
-	<div>{{.Description}} {{.Website}}</div>
-	<hr>
-	</div>
-	{{ end }}
+{{ end }}
 `

--- a/internal/resources/templates/repolist.go
+++ b/internal/resources/templates/repolist.go
@@ -35,26 +35,69 @@ const RepoList = `
 </div>
 	{{end}}
 `
-
-// TODO: Map .ToLower func into this template to lowercase the $hookname in the URL
-const RepoPage = `
-{{ define "content" }}
-	<br/><br/>
-	<div>
+const repoPage = `
+{{define "content"}}
+	<div class="repository file list">
 		<div><b>{{.FullName}}</b></div>
 		<div><b>Available validators</b>:<br>
-		{{ range $hookname, $hook := .Hooks }}
-			{{ $hookname }}
-			{{ if eq $hook.State 0 }}
-				[Enabled] <a href="/repos/{{$.FullName}}/{{ $hook.ID }}/disable">disable</a>
-			{{ else }}
-					[Disabled] <a href="/repos/{{$.FullName}}/{{ $hookname }}/enable">enable</a>
-			{{ end }}
-				<br>
-			{{ end }}
+		{{range $hookname, $hook := .Hooks}}
+			{{$hookname}}
+			{{if eq $hook.State 0}}
+				[Enabled] <a href="/repos/{{$.FullName}}/{{$hook.ID}}/disable">disable</a>
+			{{else}}
+					[Disabled] <a href="/repos/{{$.FullName}}/{{$hookname}}/enable">enable</a>
+			{{end}}
+			<br>
+		{{end}}
 		</div>
 		<div>{{.Description}} {{.Website}}</div>
 		<hr>
 	</div>
-{{ end }}
+{{end}}
+`
+
+const RepoPage = `
+{{define "content"}}
+	<div class="repository file list">
+		<div class="header-wrapper">
+			<div class="ui container">
+				<div class="ui vertically padded grid head">
+					<div class="column">
+						<div class="ui header">
+							<div class="ui huge breadcrumb">
+								<i class="mega-octicon octicon-repo"></i>
+								{{.FullName}}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="ui tabs container">
+			</div>
+			<div class="ui tabs divider"></div>
+		</div>
+		<div class="ui container">
+			<p id="repo-desc">
+			<span class="description has-emoji">{{.Description}}</span>
+			<a class="link" href=""></a>
+			</p>
+			<table id="repo-files-table" class="ui unstackable fixed single line table">
+				<tbody>
+					{{range $hookname, $hook := .Hooks}}
+						<tr>
+							<td class="name text bold four wide"><a href="">{{$hookname | ToUpper}}</a></td>
+							{{if eq $hook.State 0}}
+								<td class="name nine wide"><a href="">RESULTS</a></td>
+								<td class="name three wide"><a href="/repos/{{$.FullName}}/{{$hook.ID}}/disable">DEACTIVATE</a></td>
+							{{else}}
+								<td class="name nine wide">N/A</td>
+								<td class="name three wide"><a href="/repos/{{$.FullName}}/{{$hookname}}/enable">ACTIVATE</a></td>
+							{{end}}
+						</tr>
+					{{end}}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{{end}}
 `

--- a/internal/web/hooks.go
+++ b/internal/web/hooks.go
@@ -42,7 +42,7 @@ func EnableHook(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusUnauthorized, err.Error())
 		return
 	}
-	http.Redirect(w, r, fmt.Sprintf("/repos/%s", ut.Username), http.StatusFound)
+	http.Redirect(w, r, fmt.Sprintf("/repos/%s/hooks", repopath), http.StatusFound)
 }
 
 // DisableHook removes a hook from the server.
@@ -72,7 +72,7 @@ func DisableHook(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusUnauthorized, err.Error())
 		return
 	}
-	http.Redirect(w, r, fmt.Sprintf("/repos/%s", ut.Username), http.StatusFound)
+	http.Redirect(w, r, fmt.Sprintf("/repos/%s/hooks", repopath), http.StatusFound)
 }
 
 func checkHookSecret(data []byte, secret string) bool {

--- a/internal/web/user.go
+++ b/internal/web/user.go
@@ -381,6 +381,11 @@ func ShowRepo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tmpl := template.New("layout")
+	funcmap := map[string]interface{}{
+		"ToLower": strings.ToLower,
+		"ToUpper": strings.ToUpper,
+	}
+	tmpl.Funcs(funcmap)
 	tmpl, err = tmpl.Parse(templates.Layout)
 	if err != nil {
 		log.Write("[Error] failed to parse html layout page")

--- a/internal/web/user.go
+++ b/internal/web/user.go
@@ -153,8 +153,13 @@ func LoginGet(w http.ResponseWriter, r *http.Request) {
 func LoginPost(w http.ResponseWriter, r *http.Request) {
 	log.Write("Doing login")
 	r.ParseForm()
-	username := r.Form["username"][0]
-	password := r.Form["password"][0]
+	username := r.FormValue("username")
+	password := r.FormValue("password")
+	if username == "" || password == "" {
+		log.Write("[error] Invalid form data")
+		fail(w, http.StatusUnauthorized, "authentication failed")
+		return
+	}
 	sessionid, err := doLogin(username, password)
 	if err != nil {
 		log.Write("[error] Login failed: %s", err.Error())

--- a/internal/web/user.go
+++ b/internal/web/user.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/G-Node/gin-cli/ginclient"
@@ -226,6 +227,11 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Printf("Got %d repos\n", len(userrepos))
 	tmpl := template.New("layout")
+	funcmap := map[string]interface{}{
+		"ToLower": strings.ToLower,
+		"ToUpper": strings.ToUpper,
+	}
+	tmpl.Funcs(funcmap)
 	tmpl, err = tmpl.Parse(templates.Layout)
 	if err != nil {
 		log.Write("[Error] failed to parse html layout page")


### PR DESCRIPTION
Prettified the templates so that they look a lot like GIN now.  I adapted a bunch of layouts from GIN templates.  The gin-valid templates use assets from https://gin.g-node.org but these should be moved to a separate location soon.

Below are some screenshots of what the pages look like now.

Octicons aren't rendered but they should show up once it's up and running on a proper server or if we copy the assets to the server.

![image](https://user-images.githubusercontent.com/2369197/63367449-22e05900-c37c-11e9-9d12-7fb55a0e3d8c.png)
![image](https://user-images.githubusercontent.com/2369197/63367548-5cb15f80-c37c-11e9-8148-66c9e6ac1454.png)
![image](https://user-images.githubusercontent.com/2369197/63367562-663ac780-c37c-11e9-98f2-d2573f664f92.png)
![image](https://user-images.githubusercontent.com/2369197/63367584-70f55c80-c37c-11e9-9a11-a707653fa280.png)
![image](https://user-images.githubusercontent.com/2369197/63367655-a1d59180-c37c-11e9-9ee0-087e71236abb.png)
