### PR TITLE
odML validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,19 @@ RUN echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/reposito
         git \
         nodejs \
         npm \
-        openssh
+        openssh \
+        python3 \
+        py3-lxml
 
 # Install the BIDS validator
 RUN npm install -g bids-validator
+
+# Install odml for odML validation
+RUN pip3 install -U pip
+RUN pip3 install odml
+
+# Copy odML validation script
+COPY ./scripts/odml-validate /bin
 
 # Copy git-annex from builder image
 COPY --from=binbuilder /git-annex /git-annex

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 type Executables struct {
 	BIDS string `json:"bids"`
 	NIX  string `json:"nix"`
+	ODML string `json:"odml"`
 }
 
 // Directories used by the server for temporary and long term storage.
@@ -67,12 +68,12 @@ var defaultCfg = ServerCfg{
 		ClientID:    "gin-valid",
 		HookSecret:  "",
 		CookieName:  "gin-valid-session",
-		// NOTE: NIX isn't actually supported yet, but having a second value helps with testing
-		Validators: []string{"bids", "nix"},
+		Validators:  []string{"bids", "nix", "odml"},
 	},
 	Executables{
 		BIDS: "bids-validator",
 		NIX:  "nixio-tool",
+		ODML: "odml-validate",
 	},
 	Directories{
 		Temp:   filepath.Join(os.Getenv("GINVALIDHOME"), "tmp"),

--- a/internal/resources/templates/generic_results.go
+++ b/internal/resources/templates/generic_results.go
@@ -1,6 +1,8 @@
 package templates
 
-const NIXResults = `
+// GenericResults is a template that requires only a header text, a badge, and
+// content. The content is displayed in a <pre> block.
+const GenericResults = `
 {{define "content"}}
 	<div class="repository file list">
 		<div class="header-wrapper">

--- a/scripts/odml-validate
+++ b/scripts/odml-validate
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import os
+import sys
+import odml
+from odml.tools.parser_utils import InvalidVersionException, ParserException
+
+
+def val(fname):
+    doc = odml.load(fname)
+    res = odml.validation.Validation(doc)
+    return res
+
+
+def errtostring(error):
+    return f"[{error.rank}] {error.path}: {error.msg}"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("Please provide the path to at least one file to validate")
+
+    filenames = sys.argv[1:]
+    fileerrors = dict()
+    for fname in filenames:
+        if (os.path.exists(fname) and
+                (os.path.isfile(fname) or os.path.islink(fname))):
+            print(f"Validating {fname}...", flush=True, end=" ")
+            try:
+                v = val(fname)
+                msgs = [errtostring(err) for err in v.errors]
+            except InvalidVersionException as ve:
+                msgs = [f"[error] Unsupported file format version: {ve}"]
+            except ParserException as pe:
+                msgs = [f"[fatal] Invalid odML file: {pe}"]
+            fileerrors[fname] = msgs
+            print("done")
+        else:
+            print(f"{fname} is not a file. Skipping validation.")
+
+    print(f"Completed validation of {len(filenames)} files")
+
+    print("=== RESULTS ===")
+    for fname, errors in fileerrors.items():
+        if len(errors):
+            print(f":: {fname}: {len(errors)} issues found")
+            for err in errors:
+                print(f"    {err}")
+        else:
+            print(f":: {fname} successfully validated "
+                  "with no warnings or errors")


### PR DESCRIPTION
odML validator functions and validation script.

The output isn't pretty.  Much like NIX, the template simply puts the output of the validation script between `<pre>` tags.  We can make the output of the script look nicer for now.  Later we can make it print out JSON output that gin-valid can then read and format accordingly.