### PR TITLE
Fix one-time validation

### DIFF
--- a/cmd/ginvalid/main.go
+++ b/cmd/ginvalid/main.go
@@ -44,6 +44,7 @@ func registerRoutes(r *mux.Router) {
 	r.HandleFunc("/validate/{validator}/{user}/{repo}", web.Validate).Methods("POST")
 	r.HandleFunc("/status/{validator}/{user}/{repo}", web.Status).Methods("GET")
 	r.HandleFunc("/results/{validator}/{user}/{repo}", web.Results).Methods("GET")
+	r.HandleFunc("/results/{validator}/{user}/{repo}/{id}", web.Results).Methods("GET")
 	r.HandleFunc("/login", web.LoginGet).Methods("GET")
 	r.HandleFunc("/login", web.LoginPost).Methods("POST")
 	r.HandleFunc("/repos", web.ListRepos).Methods("GET")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/gogits/go-gogs-client v0.0.0-20190710002546-4c3c18947c15
 	github.com/gogs/go-gogs-client v0.0.0-20190710002546-4c3c18947c15
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/magiconair/properties v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=

--- a/internal/resources/templates/pubvalidate.go
+++ b/internal/resources/templates/pubvalidate.go
@@ -18,20 +18,20 @@ var PubValidate = `
 			<div class="ui segment field">
 				<h4>Validators</h4>
 				<div class="inline field">
-					<div class="ui checkbox">
-						<input name="bids" type="checkbox" tabindex="0">
+					<div class="ui radio checkbox">
+						<input name="validator" value="bids" type="radio">
 						<label><strong>BIDS</strong> Brain Imaging Data Structure: link-to-bids-website</label>
 					</div>
 				</div>
 				<div class="inline field">
-					<div class="ui checkbox">
-						<input name="nix" type="checkbox" tabindex="0">
+					<div class="ui radio checkbox">
+						<input name="validator" value="nix" type="radio">
 						<label><strong>NIX</strong> Neuroscience Information Exchange format link-to-nix-website</label>
 					</div>
 				</div>
 				<div class="inline field">
-					<div class="ui checkbox">
-						<input name="odml" type="checkbox" tabindex="0">
+					<div class="ui radio checkbox">
+						<input name="validator" value="odml" type="radio">
 						<label><strong>odML</strong> Open Metadata Markup Language link-to-odml-website</label>
 					</div>
 				</div>

--- a/internal/resources/templates/pubvalidate.go
+++ b/internal/resources/templates/pubvalidate.go
@@ -26,7 +26,7 @@ var PubValidate = `
 				<div class="inline field">
 					<div class="ui checkbox">
 						<input name="nix" type="checkbox" tabindex="0">
-						<label><strong>NIX</strong> Neurosciene Information Exchange format link-to-nix-website</label>
+						<label><strong>NIX</strong> Neuroscience Information Exchange format link-to-nix-website</label>
 					</div>
 				</div>
 				<div class="inline field">

--- a/internal/web/results.go
+++ b/internal/web/results.go
@@ -109,7 +109,12 @@ func Results(w http.ResponseWriter, r *http.Request) {
 	log.ShowWrite("[Info] '%s' results for repo '%s/%s'\n", validator, user, repo)
 
 	srvcfg := config.Read()
-	resdir := filepath.Join(srvcfg.Dir.Result, validator, user, repo, srvcfg.Label.ResultsFolder)
+	resID, ok := vars["id"]
+	if !ok {
+		fmt.Println("Results ID not specified: Rendering default")
+		resID = srvcfg.Label.ResultsFolder
+	}
+	resdir := filepath.Join(srvcfg.Dir.Result, validator, user, repo, resID)
 
 	fp := filepath.Join(resdir, srvcfg.Label.ResultsBadge)
 	badge, err := ioutil.ReadFile(fp)

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -527,7 +527,6 @@ func PubValidatePost(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusUnauthorized, msg)
 		return
 	}
-	defer gcl.Logout()
 
 	// check if repository is accessible
 	repoinfo, err := gcl.GetRepo(repopath)

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/G-Node/gin-valid/internal/resources/templates"
 	gogs "github.com/gogits/go-gogs-client"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -460,6 +461,121 @@ func runValidator(validator, repopath, commit string, gcl *ginclient.Client) {
 	}()
 }
 
+func runValidatorPub(validator, repopath string, gcl *ginclient.Client) string {
+	uuid := uuid.New()
+	respath := filepath.Join(validator, repopath, uuid.String())
+	go func() {
+		log.ShowWrite("[Info] Running %s validation on repository %q (HEAD)", validator, repopath)
+
+		// TODO add check if a repo is currently being validated. Since the cloning
+		// can potentially take quite some time prohibit running the same
+		// validation at the same time. Could also move this to a mapped go
+		// routine and if the same repo is validated twice, the first occurrence is
+		// stopped and cleaned up while the second starts anew - to make sure its
+		// always the latest state of the repository that is being validated.
+
+		srvcfg := config.Read()
+		resdir := filepath.Join(srvcfg.Dir.Result, respath)
+
+		// Create results folder if necessary
+		// CHECK: can this lead to a race condition, if a job for the same user/repo combination is started twice in short succession?
+		err := os.MkdirAll(resdir, os.ModePerm)
+		if err != nil {
+			log.ShowWrite("[Error] creating %q results folder: %s", resdir, err.Error())
+			return
+		}
+
+		tmpdir, err := ioutil.TempDir(srvcfg.Dir.Temp, validator)
+		if err != nil {
+			log.ShowWrite("[Error] Internal error: Couldn't create temporary gin directory: %s", err.Error())
+			writeValFailure(resdir)
+			return
+		}
+
+		repopathparts := strings.SplitN(repopath, "/", 2)
+		_, repo := repopathparts[0], repopathparts[1]
+		valroot := filepath.Join(tmpdir, repo)
+
+		// Enable cleanup once tried and tested
+		defer os.RemoveAll(tmpdir)
+
+		// Add the processing badge and message to display while the validator runs
+		procBadge := filepath.Join(resdir, srvcfg.Label.ResultsBadge)
+		err = ioutil.WriteFile(procBadge, []byte(resources.ProcessingBadge), os.ModePerm)
+		if err != nil {
+			log.ShowWrite("[Error] writing results badge for %q", valroot)
+		}
+
+		outFile := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+		err = ioutil.WriteFile(outFile, []byte(progressmsg), os.ModePerm)
+		if err != nil {
+			log.ShowWrite("[Error] writing results file for %q", valroot)
+		}
+
+		// err = makeSessionKey(gcl, commit)
+		// if err != nil {
+		// 	log.ShowWrite("[error] failed to create session key: %s", err.Error())
+		// 	writeValFailure(resdir)
+		// 	return
+		// }
+		// defer deleteSessionKey(gcl, commit)
+
+		// TODO: if (annexed) content is not available yet, wait and retry.  We
+		// would have to set a max timeout for this.  The issue is that when a user
+		// does a 'gin upload' a push happens immediately and the hook is
+		// triggered, but annexed content is only transferred after the push and
+		// could take a while (hours?). The validation service should try to
+		// download content after the transfer is complete, or should keep retrying
+		// until it's available, with a timeout. We could also make it more
+		// efficient by only downloading the content in the directories which are
+		// specified in the validator config (if it exists).
+
+		glog.Init()
+		clonechan := make(chan git.RepoFileStatus)
+		os.Chdir(tmpdir)
+		go gcl.CloneRepo(repopath, clonechan)
+		for stat := range clonechan {
+			if stat.Err != nil {
+				log.ShowWrite("[Error] Failed to fetch repository data for %q: %s", repopath, stat.Err.Error())
+				writeValFailure(resdir)
+				return
+			}
+			log.ShowWrite("[Info] %s %s", stat.State, stat.Progress)
+		}
+		log.ShowWrite("[Info] clone complete for '%s'", repopath)
+
+		log.ShowWrite("[Info] Downloading content")
+		getcontentchan := make(chan git.RepoFileStatus)
+		// TODO: Get only the content for the files that will be validated
+		go gcl.GetContent([]string{"."}, getcontentchan)
+		for stat := range getcontentchan {
+			if stat.Err != nil {
+				log.ShowWrite("[Error] failed to get content for %q: %s", repopath, stat.Err.Error())
+				writeValFailure(resdir)
+				return
+			}
+			log.ShowWrite("[Info] %s %s %s", stat.State, stat.FileName, stat.Progress)
+		}
+		log.ShowWrite("[Info] get-content complete")
+
+		switch validator {
+		case "bids":
+			err = validateBIDS(valroot, resdir)
+		case "nix":
+			err = validateNIX(valroot, resdir)
+		case "odml":
+			err = validateODML(valroot, resdir)
+		default:
+			err = fmt.Errorf("[Error] invalid validator name: %s", validator)
+		}
+
+		if err != nil {
+			writeValFailure(resdir)
+		}
+	}()
+	return respath
+}
+
 // writeValFailure writes a badge and page content for when a hook payload is
 // valid, but the validator failed to run.  This function does not return
 // anything, but logs all errors.
@@ -543,10 +659,8 @@ func PubValidatePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	runValidator(validator, repopath, "HEAD", gcl)
-	// TODO redirect to results
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	respath := runValidatorPub(validator, repopath, gcl)
+	http.Redirect(w, r, filepath.Join("results", respath), http.StatusFound)
 }
 
 // Validate temporarily clones a provided repository from

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -515,7 +515,7 @@ func PubValidatePost(w http.ResponseWriter, r *http.Request) {
 
 	r.ParseForm()
 	repopath := r.Form["repopath"][0]
-	validator := "bids" // vars["validator"] // TODO: add options to root form
+	validator := r.Form["validator"][0]
 
 	log.ShowWrite("[Info] About to validate repository '%s' with %s", repopath, ginuser)
 	log.ShowWrite("[Info] Logging in to GIN server")


### PR DESCRIPTION
### New public variant of validator function

New function differs in cloning procedure and directory locations:
- Doesn't take specific commit to validate: Only validates HEAD
- Results are stored in a unique directory (UUID)
- Results directory is returned to the calling function and the user is redirected to the results page, which should show **In Progress** until the validation is finished and the user reloads the page.

New route for specific validation results
- Parent route (`/results/validator/user/repo`) loads "latest" results (same as before).
- New route (`/results/validator/user/repo/id`) loads results matching "id", which is either a commit hash (for a validation triggered by a hook) or a UUID (for a validation triggered by one-time pubvalidate).

Closes #18 