### PR TITLE
Repository list: separate active from inactive repositories

### DIFF
--- a/internal/resources/templates/generic_results.go
+++ b/internal/resources/templates/generic_results.go
@@ -26,9 +26,7 @@ const GenericResults = `
 		<div class="ui container">
 	<hr>
 	<div>
-		<pre>
-			{{.Content}}
-		</pre>
+		<pre>{{.Content}}</pre>
 	</div>
 {{end}}
 `

--- a/internal/resources/templates/generic_results.go
+++ b/internal/resources/templates/generic_results.go
@@ -24,9 +24,11 @@ const GenericResults = `
 			<div class="ui tabs divider"></div>
 		</div>
 		<div class="ui container">
-	<hr>
-	<div>
-		<pre>{{.Content}}</pre>
+			<hr>
+			<div>
+				<pre>{{.Content}}</pre>
+			</div>
+		</div>
 	</div>
 {{end}}
 `

--- a/internal/resources/templates/repolist.go
+++ b/internal/resources/templates/repolist.go
@@ -6,7 +6,7 @@ const RepoList = `
 
 <div class="explore repositories">
 	<div class="ui container repository list">
-		{{range .}}
+		{{range .Active}}
 			{{$repopath := .FullName}}
 			<div class="item">
 				<div class="ui grid">
@@ -24,6 +24,25 @@ const RepoList = `
 							{{end}}
 						{{end}}
 							</div>
+						</div>
+						<p class="has-emoji">{{.Description}}</p>
+						<a href="{{.HTMLURL}}">Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">Repository hooks</a>
+					</div>
+				</div>
+			</div>
+		{{end}}
+		<hr>
+		<h2>Inactive repositories</h2>
+		{{range .Inactive}}
+			{{$repopath := .FullName}}
+			<div class="item">
+				<div class="ui grid">
+					<div class="ui two wide column middle aligned center">
+						<i class="mega-octicon octicon-repo"></i>
+					</div>
+					<div class="ui fourteen wide column">
+						<div class="ui header">
+							<a class="name" href="/repos/{{$repopath}}/hooks">{{$repopath}}</a>
 						</div>
 						<p class="has-emoji">{{.Description}}</p>
 						<a href="{{.HTMLURL}}">Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">Repository hooks</a>


### PR DESCRIPTION
When collecting repositories, separate into active (has a validator hook enabled) and inactive (no validator hooks enabled) repositories.  In the template, render the lists separately, with the active repositories at the top and the inactive ones separately below.

Closes #49.

Small fixes for the results page also included.