### PR TITLE
Page refresh hint on one-time validation (#59) resolved

### DIFF
--- a/internal/web/pkg.go
+++ b/internal/web/pkg.go
@@ -7,5 +7,5 @@ package web
 
 const (
 	serveralias = "gin"
-	progressmsg = "A validation job for this repository is currently in progress"
+	progressmsg = "A validation job for this repository is currently in progress, please do not leave this page and refresh the page after a while."
 )


### PR DESCRIPTION
When running a public one-time validation, the text should give a hint to leave the page open and refresh to see the validation results.