### PR TITLE
Not selecting validator results in panic (#58) resolved

### DIFF
--- a/internal/resources/templates/pubvalidate.go
+++ b/internal/resources/templates/pubvalidate.go
@@ -19,7 +19,7 @@ var PubValidate = `
 				<h4>Validators</h4>
 				<div class="inline field">
 					<div class="ui radio checkbox">
-						<input name="validator" value="bids" type="radio">
+						<input name="validator" value="bids" type="radio" checked="checked">
 						<label><strong>BIDS</strong> Brain Imaging Data Structure: link-to-bids-website</label>
 					</div>
 				</div>

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -630,6 +630,12 @@ func PubValidatePost(w http.ResponseWriter, r *http.Request) {
 
 	r.ParseForm()
 	repopath := r.Form["repopath"][0]
+	validators := r.Form["validator"]
+	if len(validators) < 1 {
+		log.ShowWrite("[error] no validator selected")
+		fail(w, http.StatusBadRequest, "No validator has been selected")
+		return
+	}
 	validator := r.Form["validator"][0]
 
 	log.ShowWrite("[Info] About to validate repository '%s' with %s", repopath, ginuser)


### PR DESCRIPTION
Closes #58

"When choosing a one-time-validation and not selecting any validator, the server panics and the user is confronted with a "Secure connection failed" page."

On the frontend side, there is the first option already choosen by
default.
On the backend side, if no valdidator is selected, the user
gets 400: Bad Request with message "No validator has been selected"