### PR TITLE
"Back to GIN" link should be dynamic (#56) resolved

### DIFF
--- a/internal/resources/templates/layout.go
+++ b/internal/resources/templates/layout.go
@@ -29,10 +29,10 @@ var Layout = `
 					<div class="ui grid">
 						<div class="column">
 							<div class="ui top secondary menu">
-								<a class="item brand" href="https://gin.g-node.org/">
+								<a class="item brand" href="{{.GinURL}}">
 									<img class="ui mini image" src="/assets/favicon.png">
 								</a>
-								<a class="item" href="https://gin.g-node.org/">Back to GIN</a>
+								<a class="item" href="{{.GinURL}}">Back to GIN</a>
 								<a class="item" href="/repos">Repositories</a>
 								<a class="item" href="/pubvalidate">One-time validation</a>
 								<a class="item" href="/login">Login</a>

--- a/internal/web/fail.go
+++ b/internal/web/fail.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/G-Node/gin-valid/internal/config"
 	"github.com/G-Node/gin-valid/internal/log"
 	"github.com/G-Node/gin-valid/internal/resources/templates"
 )
@@ -26,14 +27,17 @@ func fail(w http.ResponseWriter, status int, message string) {
 		w.Write([]byte(message))
 		return
 	}
+	srvcfg := config.Read()
 	errinfo := struct {
 		StatusCode int
 		StatusText string
 		Message    string
+		GinURL     string
 	}{
 		status,
 		http.StatusText(status),
 		message,
+		srvcfg.GINAddresses.WebURL,
 	}
 	tmpl.Execute(w, &errinfo)
 }

--- a/internal/web/results.go
+++ b/internal/web/results.go
@@ -167,11 +167,13 @@ func renderInProgress(w http.ResponseWriter, r *http.Request, badge []byte, vali
 
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("%s validation for %s/%s", validator, user, repo)
+	srvcfg := config.Read()
 	info := struct {
 		Badge   template.HTML
 		Header  string
 		Content string
-	}{template.HTML(badge), head, string(progressmsg)}
+		GinURL  string
+	}{template.HTML(badge), head, string(progressmsg), srvcfg.GINAddresses.WebURL}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
@@ -208,11 +210,13 @@ func renderBIDSResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("BIDS validation for %s/%s", user, repo)
+	srvcfg := config.Read()
 	info := struct {
 		Badge  template.HTML
 		Header string
 		*BidsResultStruct
-	}{template.HTML(badge), head, &resBIDS}
+		GinURL string
+	}{template.HTML(badge), head, &resBIDS, srvcfg.GINAddresses.WebURL}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
@@ -241,11 +245,13 @@ func renderNIXResults(w http.ResponseWriter, r *http.Request, badge []byte, cont
 
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("NIX validation for %s/%s", user, repo)
+	srvcfg := config.Read()
 	info := struct {
 		Badge   template.HTML
 		Header  string
 		Content string
-	}{template.HTML(badge), head, string(content)}
+		GinURL  string
+	}{template.HTML(badge), head, string(content), srvcfg.GINAddresses.WebURL}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
@@ -274,11 +280,13 @@ func renderODMLResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("odML validation for %s/%s", user, repo)
+	srvcfg := config.Read()
 	info := struct {
 		Badge   template.HTML
 		Header  string
 		Content string
-	}{template.HTML(badge), head, string(content)}
+		GinURL  string
+	}{template.HTML(badge), head, string(content), srvcfg.GINAddresses.WebURL}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {

--- a/internal/web/user.go
+++ b/internal/web/user.go
@@ -167,7 +167,13 @@ func LoginGet(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
-	tmpl.Execute(w, nil)
+	srvcfg := config.Read()
+	data := struct {
+		GinURL string
+	}{
+		srvcfg.GINAddresses.WebURL,
+	}
+	tmpl.Execute(w, &data)
 }
 
 // LoginPost logs in the user to the GIN server, storing a session token.
@@ -291,12 +297,15 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 			reposInactive = append(reposInactive, rhinfo)
 		}
 	}
+	srvcfg := config.Read()
 	allrepos := struct {
 		Active   []repoHooksInfo
 		Inactive []repoHooksInfo
+		GinURL   string
 	}{
 		reposActive,
 		reposInactive,
+		srvcfg.GINAddresses.WebURL,
 	}
 	tmpl.Execute(w, &allrepos)
 }
@@ -446,6 +455,15 @@ func ShowRepo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		hooks = make(map[string]ginhook)
 	}
-	repohi := repoHooksInfo{repoinfo, hooks}
+	srvcfg := config.Read()
+	repohi := struct {
+		gogs.Repository
+		Hooks  map[string]ginhook
+		GinURL string
+	}{
+		repoinfo,
+		hooks,
+		srvcfg.GINAddresses.WebURL,
+	}
 	tmpl.Execute(w, &repohi)
 }

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -619,7 +619,13 @@ func PubValidateGet(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
-	tmpl.Execute(w, nil)
+	srvcfg := config.Read()
+	data := struct {
+		GinURL string
+	}{
+		srvcfg.GINAddresses.WebURL,
+	}
+	tmpl.Execute(w, &data)
 }
 
 // PubValidatePost parses the POST data from the root form and calls the


### PR DESCRIPTION
Closes #56

There was the hardcoded url to gin.g-node.org which is fine for the live service, but for development and testing purposes it would be better to set this link via the config.

The url is propagated through GinUrl variable directly to the template