### PR TITLE
Add icon to signify external links (#53) resolved

### DIFF
--- a/internal/resources/templates/repolist.go
+++ b/internal/resources/templates/repolist.go
@@ -26,7 +26,7 @@ const RepoList = `
 							</div>
 						</div>
 						<p class="has-emoji">{{.Description}}</p>
-						<a href="{{.HTMLURL}}">Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">Repository hooks</a>
+						<a href="{{.HTMLURL}}">&#128279; Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">&#128279; Repository hooks</a>
 					</div>
 				</div>
 			</div>
@@ -45,7 +45,7 @@ const RepoList = `
 							<a class="name" href="/repos/{{$repopath}}/hooks">{{$repopath}}</a>
 						</div>
 						<p class="has-emoji">{{.Description}}</p>
-						<a href="{{.HTMLURL}}">Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">Repository hooks</a>
+						<a href="{{.HTMLURL}}">&#128279; Repository on GIN</a> | <a href="{{.HTMLURL}}/settings/hooks">&#128279; Repository hooks</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #53

"The two Repository links on the Repo list page, "Repository on GIN" and "Repository hooks" link to the GIN server. We should add an external link icon (maybe link symbol?) to signify that this links offsite."

The icons are simply added using unicode character sequences.