### PR TITLE
Add dynamic (c) date in page footer (#67) resolved

### DIFF
--- a/internal/resources/templates/layout.go
+++ b/internal/resources/templates/layout.go
@@ -46,7 +46,7 @@ var Layout = `
 		<footer>
 			<div class="ui container">
 				<div class="ui center links item brand footertext">
-					<a href="http://www.g-node.org"><img class="ui mini footericon" src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>© G-Node, 2016-2019</a>
+					<a href="http://www.g-node.org"><img class="ui mini footericon" src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>© G-Node, 2016-{{.CurrentYear}}</a>
 					<a href="https://gin.g-node.org/G-Node/Info/wiki/about">About</a>
 					<a href="https://gin.g-node.org/G-Node/Info/wiki/imprint">Imprint</a>
 					<a href="https://gin.g-node.org/G-Node/Info/wiki/contact">Contact</a>

--- a/internal/web/fail.go
+++ b/internal/web/fail.go
@@ -3,6 +3,7 @@ package web
 import (
 	"html/template"
 	"net/http"
+	"time"
 
 	"github.com/G-Node/gin-valid/internal/config"
 	"github.com/G-Node/gin-valid/internal/log"
@@ -27,17 +28,20 @@ func fail(w http.ResponseWriter, status int, message string) {
 		w.Write([]byte(message))
 		return
 	}
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	errinfo := struct {
-		StatusCode int
-		StatusText string
-		Message    string
-		GinURL     string
+		StatusCode  int
+		StatusText  string
+		Message     string
+		GinURL      string
+		CurrentYear int
 	}{
 		status,
 		http.StatusText(status),
 		message,
 		srvcfg.GINAddresses.WebURL,
+		year,
 	}
 	tmpl.Execute(w, &errinfo)
 }

--- a/internal/web/results.go
+++ b/internal/web/results.go
@@ -168,12 +168,14 @@ func renderInProgress(w http.ResponseWriter, r *http.Request, badge []byte, vali
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("%s validation for %s/%s", validator, user, repo)
 	srvcfg := config.Read()
+	year, _, _ := time.Now().Date()
 	info := struct {
-		Badge   template.HTML
-		Header  string
-		Content string
-		GinURL  string
-	}{template.HTML(badge), head, string(progressmsg), srvcfg.GINAddresses.WebURL}
+		Badge       template.HTML
+		Header      string
+		Content     string
+		GinURL      string
+		CurrentYear int
+	}{template.HTML(badge), head, string(progressmsg), srvcfg.GINAddresses.WebURL, year}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
@@ -210,13 +212,15 @@ func renderBIDSResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("BIDS validation for %s/%s", user, repo)
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	info := struct {
 		Badge  template.HTML
 		Header string
 		*BidsResultStruct
-		GinURL string
-	}{template.HTML(badge), head, &resBIDS, srvcfg.GINAddresses.WebURL}
+		GinURL      string
+		CurrentYear int
+	}{template.HTML(badge), head, &resBIDS, srvcfg.GINAddresses.WebURL, year}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
@@ -245,13 +249,15 @@ func renderNIXResults(w http.ResponseWriter, r *http.Request, badge []byte, cont
 
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("NIX validation for %s/%s", user, repo)
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	info := struct {
-		Badge   template.HTML
-		Header  string
-		Content string
-		GinURL  string
-	}{template.HTML(badge), head, string(content), srvcfg.GINAddresses.WebURL}
+		Badge       template.HTML
+		Header      string
+		Content     string
+		GinURL      string
+		CurrentYear int
+	}{template.HTML(badge), head, string(content), srvcfg.GINAddresses.WebURL, year}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
@@ -281,12 +287,14 @@ func renderODMLResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 	// Parse results into html template and serve it
 	head := fmt.Sprintf("odML validation for %s/%s", user, repo)
 	srvcfg := config.Read()
+	year, _, _ := time.Now().Date()
 	info := struct {
-		Badge   template.HTML
-		Header  string
-		Content string
-		GinURL  string
-	}{template.HTML(badge), head, string(content), srvcfg.GINAddresses.WebURL}
+		Badge       template.HTML
+		Header      string
+		Content     string
+		GinURL      string
+		CurrentYear int
+	}{template.HTML(badge), head, string(content), srvcfg.GINAddresses.WebURL, year}
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {

--- a/internal/web/user.go
+++ b/internal/web/user.go
@@ -167,11 +167,14 @@ func LoginGet(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	data := struct {
-		GinURL string
+		GinURL      string
+		CurrentYear int
 	}{
 		srvcfg.GINAddresses.WebURL,
+		year,
 	}
 	tmpl.Execute(w, &data)
 }
@@ -297,15 +300,18 @@ func ListRepos(w http.ResponseWriter, r *http.Request) {
 			reposInactive = append(reposInactive, rhinfo)
 		}
 	}
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	allrepos := struct {
-		Active   []repoHooksInfo
-		Inactive []repoHooksInfo
-		GinURL   string
+		Active      []repoHooksInfo
+		Inactive    []repoHooksInfo
+		GinURL      string
+		CurrentYear int
 	}{
 		reposActive,
 		reposInactive,
 		srvcfg.GINAddresses.WebURL,
+		year,
 	}
 	tmpl.Execute(w, &allrepos)
 }
@@ -455,15 +461,18 @@ func ShowRepo(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		hooks = make(map[string]ginhook)
 	}
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	repohi := struct {
 		gogs.Repository
-		Hooks  map[string]ginhook
-		GinURL string
+		Hooks       map[string]ginhook
+		GinURL      string
+		CurrentYear int
 	}{
 		repoinfo,
 		hooks,
 		srvcfg.GINAddresses.WebURL,
+		year,
 	}
 	tmpl.Execute(w, &repohi)
 }

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -619,11 +620,14 @@ func PubValidateGet(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusInternalServerError, "something went wrong")
 		return
 	}
+	year, _, _ := time.Now().Date()
 	srvcfg := config.Read()
 	data := struct {
-		GinURL string
+		GinURL      string
+		CurrentYear int
 	}{
 		srvcfg.GINAddresses.WebURL,
+		year,
 	}
 	tmpl.Execute(w, &data)
 }


### PR DESCRIPTION
Closes #67

"Currently the (c) G-Node date in the footer line of each page is static. Replace the static end date with a dynamic one of to the current year."

The year will be propagated to the template using CurrentYear variable