### PR TITLE
 Provide page on missing validation results (#73) resolved 

### DIFF
--- a/internal/resources/templates/not_validated_yet.go
+++ b/internal/resources/templates/not_validated_yet.go
@@ -1,0 +1,36 @@
+package templates
+
+// NotValidatedYet is a template that requires a header text, a badge, a
+// content and two links. The content is displayed in a <pre> block.
+const NotValidatedYet = `
+{{define "content"}}
+	<div class="repository file list">
+		<div class="header-wrapper">
+			<div class="ui container">
+				<div class="ui vertically padded grid head">
+					<div class="column">
+						<div class="ui header">
+							<div class="ui huge breadcrumb">
+								<i class="mega-octicon octicon-repo"></i>
+								{{.Header}}
+								{{.Badge}}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="ui tabs container">
+			</div>
+			<div class="ui tabs divider"></div>
+		</div>
+		<div class="ui container">
+			<hr>
+			<div>
+				<pre>{{.Content}}</pre>
+				<a href="{{.HrefURL1}}" alt="{{.HrefAlt1}}">{{.HrefText1}}</a> | 
+				<a href="{{.HrefURL2}}" alt="{{.HrefAlt2}}">{{.HrefText2}}</a>
+			</div>
+		</div>
+	</div>
+{{end}}
+`

--- a/internal/web/pkg.go
+++ b/internal/web/pkg.go
@@ -6,6 +6,7 @@ and disabling hooks on the GIN server running the validation.
 package web
 
 const (
-	serveralias = "gin"
-	progressmsg = "A validation job for this repository is currently in progress, please do not leave this page and refresh the page after a while."
+	serveralias     = "gin"
+	progressmsg     = "A validation job for this repository is currently in progress, please do not leave this page and refresh the page after a while."
+	notvalidatedyet = "This repository has not been validated yet. To see the results, update the repository."
 )

--- a/internal/web/results.go
+++ b/internal/web/results.go
@@ -149,8 +149,7 @@ func Results(w http.ResponseWriter, r *http.Request) {
 	fp = filepath.Join(resdir, srvcfg.Label.ResultsFile)
 	content, err := ioutil.ReadFile(fp)
 	if err != nil {
-		log.ShowWrite("[Error] serving '%s/%s' result: %s\n", user, repo, err.Error())
-		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("404 Nothing to see here...")))
+		notValidatedYet(w, r, badge, strings.ToUpper(validator), user, repo)
 		return
 	}
 
@@ -174,7 +173,51 @@ func Results(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-func renderInProgress(w http.ResponseWriter, r *http.Request, badge []byte, validator string, user, repo string) {
+func notValidatedYet(w http.ResponseWriter, r *http.Request, badge []byte, validator, user, repo string) {
+	tmpl := template.New("layout")
+	tmpl, err := tmpl.Parse(templates.Layout)
+	if err != nil {
+		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
+		return
+	}
+	tmpl, err = tmpl.Parse(templates.NotValidatedYet)
+	if err != nil {
+		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
+		return
+	}
+
+	// Parse results into html template and serve it
+	head := fmt.Sprintf("%s validation for %s/%s", validator, user, repo)
+	srvcfg := config.Read()
+	year, _, _ := time.Now().Date()
+	info := struct {
+		Badge       template.HTML
+		Header      string
+		Content     string
+		GinURL      string
+		CurrentYear int
+		HrefURL1    string
+		HrefAlt1    string
+		HrefText1   string
+		HrefURL2    string
+		HrefAlt2    string
+		HrefText2   string
+	}{template.HTML(badge), head, string(notvalidatedyet), srvcfg.GINAddresses.WebURL, year,
+		"/pubvalidate", "Validate now", "Validate this repository right now",
+		filepath.Join("/repos", user, repo, "hooks"), "Go Back", "Go back to repository information page",
+	}
+
+	err = tmpl.ExecuteTemplate(w, "layout", info)
+	if err != nil {
+		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
+		return
+	}
+}
+
+func renderInProgress(w http.ResponseWriter, r *http.Request, badge []byte, validator, user, repo string) {
 	tmpl := template.New("layout")
 	tmpl, err := tmpl.Parse(templates.Layout)
 	if err != nil {


### PR DESCRIPTION
Closes #73

"Currently when a logged in user views the validator listing page for a specific repository and there are no results for a specific validator yet, the "Results" link for this validator will lead to a blank page with only the text "404 Nothing to see here ...".

Provide a full page including header and footer, an appropriate
information text and a link back to the results overview page of the
repository."

The page provides two links back to the original page as well
as to one-time validation page.