### PR TITLE
Use ioutil.TempDir for all relevant tests (#84) resolved

### DIFF
--- a/internal/web/results_test.go
+++ b/internal/web/results_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"github.com/G-Node/gin-valid/internal/config"
 	"github.com/gorilla/mux"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,18 +23,19 @@ func TestResultsUnsupportedV2(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/wtf", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
+	resultfldr, _ := ioutil.TempDir("", "results")
 	srvcfg := config.Read()
 	srvcfg.Settings.Validators = append(srvcfg.Settings.Validators, "wtf")
+	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
-	os.MkdirAll(filepath.Join(srvcfg.Dir.Result, "nix", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
+	os.MkdirAll(filepath.Join(resultfldr, "nix", username, reponame, id), 0755)
+	f, _ := os.Create(filepath.Join(resultfldr, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Result, "nix", username, reponame, id))
 	srvcfg.Settings.Validators = srvcfg.Settings.Validators[:len(srvcfg.Settings.Validators)-1]
 	config.Set(srvcfg)
 	status := w.Code
@@ -50,16 +52,18 @@ func TestResultsODML(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/odml", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
+	resultfldr, _ := ioutil.TempDir("", "results")
 	srvcfg := config.Read()
-	os.MkdirAll(filepath.Join(srvcfg.Dir.Result, "odml", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "odml", username, reponame, id, srvcfg.Label.ResultsFile))
+	srvcfg.Dir.Result = resultfldr
+	config.Set(srvcfg)
+	os.MkdirAll(filepath.Join(resultfldr, "odml", username, reponame, id), 0755)
+	f, _ := os.Create(filepath.Join(resultfldr, "odml", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Result, "odml", username, reponame, id))
 	status := w.Code
 	if status != http.StatusOK {
 		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
@@ -74,16 +78,18 @@ func TestResultsNIX(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/nix", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
+	resultfldr, _ := ioutil.TempDir("", "results")
 	srvcfg := config.Read()
-	os.MkdirAll(filepath.Join(srvcfg.Dir.Result, "nix", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
+	srvcfg.Dir.Result = resultfldr
+	config.Set(srvcfg)
+	os.MkdirAll(filepath.Join(resultfldr, "nix", username, reponame, id), 0755)
+	f, _ := os.Create(filepath.Join(resultfldr, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Result, "nix", username, reponame, id))
 	status := w.Code
 	if status != http.StatusOK {
 		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
@@ -98,16 +104,18 @@ func TestResultsInJSON(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
+	resultfldr, _ := ioutil.TempDir("", "results")
 	srvcfg := config.Read()
-	os.MkdirAll(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
+	srvcfg.Dir.Result = resultfldr
+	config.Set(srvcfg)
+	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
+	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id))
 	status := w.Code
 	if status != http.StatusOK {
 		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
@@ -122,16 +130,18 @@ func TestResultsInProgress(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
+	resultfldr, _ := ioutil.TempDir("", "results")
 	srvcfg := config.Read()
-	os.MkdirAll(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
+	srvcfg.Dir.Result = resultfldr
+	config.Set(srvcfg)
+	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
+	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id))
 	status := w.Code
 	if status != http.StatusOK {
 		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
@@ -146,16 +156,18 @@ func TestResultsSomeResults(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
+	resultfldr, _ := ioutil.TempDir("", "results")
 	srvcfg := config.Read()
-	os.MkdirAll(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
+	srvcfg.Dir.Result = resultfldr
+	config.Set(srvcfg)
+	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
+	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, id))
 	status := w.Code
 	if status != http.StatusOK {
 		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)


### PR DESCRIPTION
Closes #84

All tests now work using temporary folders from
io/ioutil