### PR TITLE
Refactor tests

### DIFF
--- a/internal/web/fail_test.go
+++ b/internal/web/fail_test.go
@@ -15,7 +15,7 @@ func TestFailFailedToParse(t *testing.T) {
 	templates.Layout = original
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`fail(w http.ResponseWriter, status int, message string) status code = %v`, status)
+		t.Fatalf("fail(w http.ResponseWriter, status int, message string) status code = %d", status)
 	}
 }
 
@@ -27,6 +27,6 @@ func TestFailFailedToParseFailPage(t *testing.T) {
 	templates.Fail = original
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`fail(w http.ResponseWriter, status int, message string) status code = %v`, status)
+		t.Fatalf("fail(w http.ResponseWriter, status int, message string) status code = %d", status)
 	}
 }

--- a/internal/web/hooks_test.go
+++ b/internal/web/hooks_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestHooksDisable(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/repos/{user}/{repo}/{hookid}/disable", DisableHook).Methods("GET")
@@ -31,6 +34,9 @@ func TestHooksDisable(t *testing.T) {
 }
 
 func TestHooksEnable(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/repos/{user}/{repo}/{validator}/enable", EnableHook).Methods("GET")

--- a/internal/web/hooks_test.go
+++ b/internal/web/hooks_test.go
@@ -26,7 +26,7 @@ func TestHooksDisable(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusFound {
-		t.Fatalf(`DisableHook(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("DisableHook(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -43,6 +43,6 @@ func TestHooksEnable(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusFound {
-		t.Fatalf(`EnableHook(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("EnableHook(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }

--- a/internal/web/results_test.go
+++ b/internal/web/results_test.go
@@ -16,6 +16,18 @@ import (
 )
 
 func TestResultsUnsupportedV2(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestResultsUnsupportedV2")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
 
@@ -26,18 +38,21 @@ func TestResultsUnsupportedV2(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/wtf", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	resultfldr, _ := ioutil.TempDir("", "results")
+
 	srvcfg := config.Read()
 	srvcfg.Settings.Validators = append(srvcfg.Settings.Validators, "wtf")
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
+
 	os.MkdirAll(filepath.Join(resultfldr, "nix", username, reponame, id), 0755)
 	f, _ := os.Create(filepath.Join(resultfldr, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
+
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	srvcfg.Settings.Validators = srvcfg.Settings.Validators[:len(srvcfg.Settings.Validators)-1]
 	config.Set(srvcfg)
@@ -48,30 +63,43 @@ func TestResultsUnsupportedV2(t *testing.T) {
 }
 
 func TestResultsODML(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestResultsODML")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
 
 	id := "1"
 	content := `{"empty":"json"}`
 	body := []byte("{}")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/odml", username, reponame, id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	parent := os.TempDir()
-	pth := filepath.Join(parent, "results")
-	os.Mkdir(pth, 0755)
-	resultfldr, _ := ioutil.TempDir(pth, "*-res")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
+
 	os.MkdirAll(filepath.Join(resultfldr, "odml", username, reponame, id), 0755)
 	f, _ := os.Create(filepath.Join(resultfldr, "odml", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
+
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -80,6 +108,18 @@ func TestResultsODML(t *testing.T) {
 }
 
 func TestResultsNIX(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestResultsNIX")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
 
@@ -90,20 +130,20 @@ func TestResultsNIX(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/nix", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	parent := os.TempDir()
-	pth := filepath.Join(parent, "results")
-	os.Mkdir(pth, 0755)
-	resultfldr, _ := ioutil.TempDir(pth, "*-res")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
+
 	os.MkdirAll(filepath.Join(resultfldr, "nix", username, reponame, id), 0755)
 	f, _ := os.Create(filepath.Join(resultfldr, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
+
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -112,6 +152,18 @@ func TestResultsNIX(t *testing.T) {
 }
 
 func TestResultsInJSON(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestResultsInJSON")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
 
@@ -122,20 +174,20 @@ func TestResultsInJSON(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	parent := os.TempDir()
-	pth := filepath.Join(parent, "results")
-	os.Mkdir(pth, 0755)
-	resultfldr, _ := ioutil.TempDir(pth, "*-res")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
+
 	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
 	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
+
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -144,6 +196,18 @@ func TestResultsInJSON(t *testing.T) {
 }
 
 func TestResultsInProgress(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestResultsInProgress")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
 
@@ -154,17 +218,16 @@ func TestResultsInProgress(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	parent := os.TempDir()
-	pth := filepath.Join(parent, "results")
-	os.Mkdir(pth, 0755)
-	resultfldr, _ := ioutil.TempDir(pth, "*-res")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
+
 	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
 	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
+
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
@@ -176,6 +239,18 @@ func TestResultsInProgress(t *testing.T) {
 }
 
 func TestResultsSomeResults(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestResultsSomeResults")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
 
@@ -186,20 +261,20 @@ func TestResultsSomeResults(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	parent := os.TempDir()
-	pth := filepath.Join(parent, "results")
-	os.Mkdir(pth, 0755)
-	resultfldr, _ := ioutil.TempDir(pth, "*-res")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
+
 	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
 	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
 	defer f.Close()
 	f.WriteString(content)
+
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -213,10 +288,12 @@ func TestResultsNoResults(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", "/results/bids/whatever/whatever/whatever", bytes.NewReader(body))
 	w := httptest.NewRecorder()
+
 	srvcfg := config.Read()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -230,10 +307,12 @@ func TestResultsUnsupportedValidator(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", "/results/wtf/whatever/whatever/whatever", bytes.NewReader(body))
 	w := httptest.NewRecorder()
+
 	srvcfg := config.Read()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -247,10 +326,12 @@ func TestResultsIDNotSpecified(t *testing.T) {
 	router.HandleFunc("/results/{validator}/{user}/{repo}/", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", "/results/bids/whatever/whatever/", bytes.NewReader(body))
 	w := httptest.NewRecorder()
+
 	srvcfg := config.Read()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {

--- a/internal/web/results_test.go
+++ b/internal/web/results_test.go
@@ -30,10 +30,9 @@ func TestResultsUnsupportedV2(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
 	id := "1"
-	content := `{"empty":"json"}`
 	body := []byte("{}")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/wtf", username, "/", reponame, "/", id), bytes.NewReader(body))
@@ -44,10 +43,20 @@ func TestResultsUnsupportedV2(t *testing.T) {
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
 
-	os.MkdirAll(filepath.Join(resultfldr, "nix", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(resultfldr, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
+	resdir := filepath.Join(resultfldr, "nix", username, reponame, id)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results directory: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString(`{"empty":"json"}`)
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
@@ -77,9 +86,7 @@ func TestResultsODML(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
 	id := "1"
-	content := `{"empty":"json"}`
 	body := []byte("{}")
 
 	router := mux.NewRouter()
@@ -91,10 +98,20 @@ func TestResultsODML(t *testing.T) {
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
 
-	os.MkdirAll(filepath.Join(resultfldr, "odml", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(resultfldr, "odml", username, reponame, id, srvcfg.Label.ResultsFile))
+	resdir := filepath.Join(resultfldr, "odml", username, reponame, id)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results folder: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString(`{"empty":"json"}`)
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
@@ -122,10 +139,9 @@ func TestResultsNIX(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
 	id := "1"
-	content := `{"empty":"json"}`
 	body := []byte("{}")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/nix", username, "/", reponame, "/", id), bytes.NewReader(body))
@@ -135,10 +151,20 @@ func TestResultsNIX(t *testing.T) {
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
 
-	os.MkdirAll(filepath.Join(resultfldr, "nix", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(resultfldr, "nix", username, reponame, id, srvcfg.Label.ResultsFile))
+	resdir := filepath.Join(resultfldr, "nix", username, reponame, id)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results folder: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString(`{"empty":"json"}`)
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
@@ -166,10 +192,9 @@ func TestResultsInJSON(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
 	id := "1"
-	content := `{"empty":"json"}`
 	body := []byte("{}")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
@@ -179,10 +204,20 @@ func TestResultsInJSON(t *testing.T) {
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
 
-	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
+	resdir := filepath.Join(resultfldr, "bids", username, reponame, id)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results folder: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString(`{"empty":"json"}`)
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
@@ -210,9 +245,8 @@ func TestResultsInProgress(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
 	id := "1"
-	content := progressmsg
+
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
@@ -223,10 +257,20 @@ func TestResultsInProgress(t *testing.T) {
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
 
-	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
+	resdir := filepath.Join(resultfldr, "bids", username, reponame, id)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results folder: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString(progressmsg)
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
@@ -253,10 +297,9 @@ func TestResultsSomeResults(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
 	id := "1"
-	content := "wtf"
 	body := []byte("{}")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/results/bids", username, "/", reponame, "/", id), bytes.NewReader(body))
@@ -266,10 +309,20 @@ func TestResultsSomeResults(t *testing.T) {
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
 
-	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, id), 0755)
-	f, _ := os.Create(filepath.Join(resultfldr, "bids", username, reponame, id, srvcfg.Label.ResultsFile))
+	resdir := filepath.Join(resultfldr, "bids", username, reponame, id)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results folder: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString("wtf")
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)

--- a/internal/web/results_test.go
+++ b/internal/web/results_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestResultsUnsupportedV2(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	id := "1"
 	content := `{"empty":"json"}`
 	body := []byte("{}")
@@ -45,6 +48,9 @@ func TestResultsUnsupportedV2(t *testing.T) {
 }
 
 func TestResultsODML(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	id := "1"
 	content := `{"empty":"json"}`
 	body := []byte("{}")
@@ -74,6 +80,9 @@ func TestResultsODML(t *testing.T) {
 }
 
 func TestResultsNIX(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	id := "1"
 	content := `{"empty":"json"}`
 	body := []byte("{}")
@@ -103,6 +112,9 @@ func TestResultsNIX(t *testing.T) {
 }
 
 func TestResultsInJSON(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	id := "1"
 	content := `{"empty":"json"}`
 	body := []byte("{}")
@@ -132,6 +144,9 @@ func TestResultsInJSON(t *testing.T) {
 }
 
 func TestResultsInProgress(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	id := "1"
 	content := progressmsg
 	body := []byte("{}")
@@ -161,6 +176,9 @@ func TestResultsInProgress(t *testing.T) {
 }
 
 func TestResultsSomeResults(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	id := "1"
 	content := "wtf"
 	body := []byte("{}")

--- a/internal/web/results_test.go
+++ b/internal/web/results_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestResultsUnsupportedV2(t *testing.T) {
 	id := "1"
-	content := "{\"empty\":\"json\"}"
+	content := `{"empty":"json"}`
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
@@ -40,13 +40,13 @@ func TestResultsUnsupportedV2(t *testing.T) {
 	config.Set(srvcfg)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
 func TestResultsODML(t *testing.T) {
 	id := "1"
-	content := "{\"empty\":\"json\"}"
+	content := `{"empty":"json"}`
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
@@ -69,13 +69,13 @@ func TestResultsODML(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
 func TestResultsNIX(t *testing.T) {
 	id := "1"
-	content := "{\"empty\":\"json\"}"
+	content := `{"empty":"json"}`
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
@@ -98,13 +98,13 @@ func TestResultsNIX(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
 func TestResultsInJSON(t *testing.T) {
 	id := "1"
-	content := "{\"empty\":\"json\"}"
+	content := `{"empty":"json"}`
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/results/{validator}/{user}/{repo}/{id}", Results).Methods("GET")
@@ -127,7 +127,7 @@ func TestResultsInJSON(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -156,7 +156,7 @@ func TestResultsInProgress(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -185,7 +185,7 @@ func TestResultsSomeResults(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -202,7 +202,7 @@ func TestResultsNoResults(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -219,7 +219,7 @@ func TestResultsUnsupportedValidator(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -236,6 +236,6 @@ func TestResultsIDNotSpecified(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Results(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Results(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }

--- a/internal/web/results_test.go
+++ b/internal/web/results_test.go
@@ -44,18 +44,11 @@ func TestResultsUnsupportedV2(t *testing.T) {
 	config.Set(srvcfg)
 
 	resdir := filepath.Join(resultfldr, "nix", username, reponame, id)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+	content := `{"empty":"json"}`
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results directory: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString(`{"empty":"json"}`)
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
@@ -99,18 +92,11 @@ func TestResultsODML(t *testing.T) {
 	config.Set(srvcfg)
 
 	resdir := filepath.Join(resultfldr, "odml", username, reponame, id)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+	content := `{"empty":"json"}`
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results folder: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString(`{"empty":"json"}`)
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
@@ -152,18 +138,11 @@ func TestResultsNIX(t *testing.T) {
 	config.Set(srvcfg)
 
 	resdir := filepath.Join(resultfldr, "nix", username, reponame, id)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+	content := `{"empty":"json"}`
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results folder: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString(`{"empty":"json"}`)
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
@@ -205,18 +184,11 @@ func TestResultsInJSON(t *testing.T) {
 	config.Set(srvcfg)
 
 	resdir := filepath.Join(resultfldr, "bids", username, reponame, id)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+	content := `{"empty":"json"}`
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results folder: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString(`{"empty":"json"}`)
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
@@ -258,18 +230,11 @@ func TestResultsInProgress(t *testing.T) {
 	config.Set(srvcfg)
 
 	resdir := filepath.Join(resultfldr, "bids", username, reponame, id)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+	content := progressmsg
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results folder: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString(progressmsg)
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
@@ -310,18 +275,11 @@ func TestResultsSomeResults(t *testing.T) {
 	config.Set(srvcfg)
 
 	resdir := filepath.Join(resultfldr, "bids", username, reponame, id)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsFile)
+	content := "wtf"
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results folder: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsFile))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString("wtf")
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))

--- a/internal/web/status_test.go
+++ b/internal/web/status_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestStatusOK(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	content := "wtf"
 	body := []byte("{}")
 	router := mux.NewRouter()

--- a/internal/web/status_test.go
+++ b/internal/web/status_test.go
@@ -35,7 +35,7 @@ func TestStatusOK(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Status(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Status(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -52,7 +52,7 @@ func TestStatusNoConent(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Status(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Status(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
 
@@ -69,6 +69,6 @@ func TestStatusUnsupportedValidator(t *testing.T) {
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
-		t.Fatalf(`Status(w http.ResponseWriter, r *http.Request) status code = %v`, status)
+		t.Fatalf("Status(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }

--- a/internal/web/status_test.go
+++ b/internal/web/status_test.go
@@ -16,6 +16,12 @@ import (
 )
 
 func TestStatusOK(t *testing.T) {
+	resultfldr, err := ioutil.TempDir("", "TestStatusOK")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(resultfldr)
+
 	username := "valid-testing"
 	reponame := "Testing"
 
@@ -25,16 +31,18 @@ func TestStatusOK(t *testing.T) {
 	router.HandleFunc("/status/{validator}/{user}/{repo}", Status).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/status/bids", username, reponame), bytes.NewReader(body))
 	w := httptest.NewRecorder()
-	resultfldr, _ := ioutil.TempDir("", "results")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, srvcfg.Label.ResultsFolder), 0755)
 	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, srvcfg.Label.ResultsFolder, srvcfg.Label.ResultsBadge))
 	defer f.Close()
 	f.WriteString(content)
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -48,10 +56,12 @@ func TestStatusNoConent(t *testing.T) {
 	router.HandleFunc("/status/{validator}/{user}/{repo}", Status).Methods("GET")
 	r, _ := http.NewRequest("GET", "/status/bids/whatever/whatever", bytes.NewReader(body))
 	w := httptest.NewRecorder()
+
 	srvcfg := config.Read()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {
@@ -65,10 +75,12 @@ func TestStatusUnsupportedValidator(t *testing.T) {
 	router.HandleFunc("/status/{validator}/{user}/{repo}", Status).Methods("GET")
 	r, _ := http.NewRequest("GET", "/status/whatever/whatever/whatever", bytes.NewReader(body))
 	w := httptest.NewRecorder()
+
 	srvcfg := config.Read()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
+
 	router.ServeHTTP(w, r)
 	status := w.Code
 	if status != http.StatusOK {

--- a/internal/web/status_test.go
+++ b/internal/web/status_test.go
@@ -38,18 +38,11 @@ func TestStatusOK(t *testing.T) {
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 
 	resdir := filepath.Join(resultfldr, "bids", username, reponame, srvcfg.Label.ResultsFolder)
-	err = os.MkdirAll(resdir, 0755)
+	filename := filepath.Join(resdir, srvcfg.Label.ResultsBadge)
+	content := "wtf"
+	err = createTestResultDirs(resdir, filename, content)
 	if err != nil {
-		t.Fatalf("error creating results folder: %s", err.Error())
-	}
-	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsBadge))
-	if err != nil {
-		t.Fatalf("error creating results file: %s", err.Error())
-	}
-	defer f.Close()
-	_, err = f.WriteString("wtf")
-	if err != nil {
-		t.Fatalf("error writing to results file: %s", err.Error())
+		t.Fatal(err.Error())
 	}
 
 	router.ServeHTTP(w, r)

--- a/internal/web/status_test.go
+++ b/internal/web/status_test.go
@@ -24,9 +24,8 @@ func TestStatusOK(t *testing.T) {
 
 	username := "valid-testing"
 	reponame := "Testing"
-
-	content := "wtf"
 	body := []byte("{}")
+
 	router := mux.NewRouter()
 	router.HandleFunc("/status/{validator}/{user}/{repo}", Status).Methods("GET")
 	r, _ := http.NewRequest("GET", filepath.Join("/status/bids", username, reponame), bytes.NewReader(body))
@@ -38,10 +37,20 @@ func TestStatusOK(t *testing.T) {
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 
-	os.MkdirAll(filepath.Join(resultfldr, "bids", username, reponame, srvcfg.Label.ResultsFolder), 0755)
-	f, _ := os.Create(filepath.Join(srvcfg.Dir.Result, "bids", username, reponame, srvcfg.Label.ResultsFolder, srvcfg.Label.ResultsBadge))
+	resdir := filepath.Join(resultfldr, "bids", username, reponame, srvcfg.Label.ResultsFolder)
+	err = os.MkdirAll(resdir, 0755)
+	if err != nil {
+		t.Fatalf("error creating results folder: %s", err.Error())
+	}
+	f, err := os.Create(filepath.Join(resdir, srvcfg.Label.ResultsBadge))
+	if err != nil {
+		t.Fatalf("error creating results file: %s", err.Error())
+	}
 	defer f.Close()
-	f.WriteString(content)
+	_, err = f.WriteString("wtf")
+	if err != nil {
+		t.Fatalf("error writing to results file: %s", err.Error())
+	}
 
 	router.ServeHTTP(w, r)
 	status := w.Code

--- a/internal/web/testutils.go
+++ b/internal/web/testutils.go
@@ -1,0 +1,20 @@
+package web
+
+import "os"
+
+func createTestResultDirs(resdir, filename, filecontent string) error {
+	err := os.MkdirAll(resdir, 0755)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(filecontent)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/web/token_test.go
+++ b/internal/web/token_test.go
@@ -7,27 +7,27 @@ import (
 func TestTokenLinkToSessionWrong(t *testing.T) {
 	err := linkToSession("wtf", "wtf")
 	if err == nil {
-		t.Fatalf(`linkToSession(username string, sessionid string) = %v`, err)
+		t.Fatal("expected error on linkToSession(username string, sessionid string)")
 	}
 }
 
 func TestTokenGetTokenBySessionWrong(t *testing.T) {
 	_, err := getTokenBySession("wtf")
 	if err == nil {
-		t.Fatalf(`getTokenBySession(sessionid string) = %v`, err)
+		t.Fatal("expected error on getTokenBySession(sessionid string)")
 	}
 }
 
 func TestTokenRmTokenRepoLinkWrong(t *testing.T) {
 	err := rmTokenRepoLink("wtf")
 	if err == nil {
-		t.Fatalf(`rmTokenRepoLink(repopath string) = %v`, err)
+		t.Fatal("expected error on rmTokenRepoLink(repopath string)")
 	}
 }
 
 func TestTokenGetTokenByUsernameWrong(t *testing.T) {
 	_, err := getTokenByUsername("wtf")
 	if err == nil {
-		t.Fatalf(`getTokenByUsername(username string) = %v`, err)
+		t.Fatal("expected error on getTokenByUsername(username string)")
 	}
 }

--- a/internal/web/user_test.go
+++ b/internal/web/user_test.go
@@ -9,15 +9,12 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	//"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
-	//"strings"
 	"testing"
 )
 
-// var password = "student"
 var weburl = "https://gin.dev.g-node.org:443"
 var giturl = "git@gin.dev.g-node.org:22"
 
@@ -95,48 +92,6 @@ func TestGetLoggedUserNameOK(t *testing.T) {
 	}
 }
 
-/*
-func TestUserDoLoginOK(t *testing.T) {
-	tokens, _ := ioutil.TempDir("", "tokens")
-	srvcfg := config.Read()
-	srvcfg.GINAddresses.WebURL = weburl
-	srvcfg.GINAddresses.GitURL = giturl
-	srvcfg.Dir.Tokens = tokens
-	config.Set(srvcfg)
-	tokendir := filepath.Join(tokens, "by-sessionid")
-	os.MkdirAll(tokendir, 0755)
-	sessionid, err := doLogin(username, password)
-	if sessionid == "" || err != nil {
-		t.Fatalf("doLogin(username, password) = %q, %s", sessionid, err.Error())
-	}
-}
-*/
-
-/*
-func TestUserLoginPost(t *testing.T) {
-	tokens, _ := ioutil.TempDir("", "tokens")
-	srvcfg := config.Read()
-	srvcfg.GINAddresses.WebURL = weburl
-	srvcfg.GINAddresses.GitURL = giturl
-	srvcfg.Dir.Tokens = tokens
-	config.Set(srvcfg)
-	tokendir := filepath.Join(tokens, "by-sessionid")
-	os.MkdirAll(tokendir, 0755)
-	v := make(url.Values)
-	v.Set("username", username)
-	v.Set("password", password)
-	router := mux.NewRouter()
-	router.HandleFunc("/login/{username}/{password}", LoginPost).Methods("POST")
-	r, _ := http.NewRequest("POST", filepath.Join("/login", username, password), strings.NewReader(v.Encode()))
-	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, r)
-	status := w.Code
-	if status != http.StatusFound {
-		t.Fatalf("LoginPost(w http.ResponseWriter, r *http.Request) status code = %d", status)
-	}
-}*/
-
 func TestUserLoginGet(t *testing.T) {
 	body := []byte("{}")
 	router := mux.NewRouter()
@@ -181,3 +136,48 @@ func TestUserLoginGetBadLayout(t *testing.T) {
 		t.Fatalf("LoginGet(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
+
+/*
+// Refactor tests to remove the dev server dependency
+var password = "student"
+
+func TestUserDoLoginOK(t *testing.T) {
+	tokens, _ := ioutil.TempDir("", "tokens")
+	srvcfg := config.Read()
+	srvcfg.GINAddresses.WebURL = weburl
+	srvcfg.GINAddresses.GitURL = giturl
+	srvcfg.Dir.Tokens = tokens
+	config.Set(srvcfg)
+	tokendir := filepath.Join(tokens, "by-sessionid")
+	os.MkdirAll(tokendir, 0755)
+	sessionid, err := doLogin(username, password)
+	if sessionid == "" || err != nil {
+		t.Fatalf("doLogin(username, password) = %q, %s", sessionid, err.Error())
+	}
+}
+*/
+
+/*
+func TestUserLoginPost(t *testing.T) {
+	tokens, _ := ioutil.TempDir("", "tokens")
+	srvcfg := config.Read()
+	srvcfg.GINAddresses.WebURL = weburl
+	srvcfg.GINAddresses.GitURL = giturl
+	srvcfg.Dir.Tokens = tokens
+	config.Set(srvcfg)
+	tokendir := filepath.Join(tokens, "by-sessionid")
+	os.MkdirAll(tokendir, 0755)
+	v := make(url.Values)
+	v.Set("username", username)
+	v.Set("password", password)
+	router := mux.NewRouter()
+	router.HandleFunc("/login/{username}/{password}", LoginPost).Methods("POST")
+	r, _ := http.NewRequest("POST", filepath.Join("/login", username, password), strings.NewReader(v.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	status := w.Code
+	if status != http.StatusFound {
+		t.Fatalf("LoginPost(w http.ResponseWriter, r *http.Request) status code = %d", status)
+	}
+}*/

--- a/internal/web/validate_test.go
+++ b/internal/web/validate_test.go
@@ -32,6 +32,8 @@ func TestValidateNotYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating temp dir: %s", err.Error())
 	}
+	defer os.RemoveAll(tmpdir)
+
 	testfile := filepath.Join(tmpdir, "testing-config.json")
 	f, err := os.Create(testfile)
 	if err != nil {
@@ -47,15 +49,24 @@ func TestValidateNotYAML(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error validating config, but got none; cfg: %v", valcfg)
 	}
-	defer os.RemoveAll(tmpdir)
 }
 
 func TestValidateGoodConfig(t *testing.T) {
-	f, _ := os.Create("testing-config.json")
+	tmpdir, err := ioutil.TempDir("", "TestValidateGoodConfig")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	testfile := filepath.Join(tmpdir, "testing-config.json")
+	f, err := os.Create(testfile)
+	if err != nil {
+		t.Fatalf("error creating json file: %s", err.Error())
+	}
+	defer f.Close()
+
 	f.WriteString(`empty: "true"`)
-	f.Close()
-	valcfg, err := handleValidationConfig("testing-config.json")
-	os.RemoveAll("testing-config.json")
+	valcfg, err := handleValidationConfig(testfile)
 	if err != nil {
 		t.Fatalf("handleValidationConfig(cfgpath string) = %v, %s", valcfg, err.Error())
 	}
@@ -83,18 +94,36 @@ func TestValidateODMLNoData(t *testing.T) {
 }
 
 func TestValidateBIDSOK(t *testing.T) {
-	resultfldr, _ := ioutil.TempDir("", "results")
-	tempdataset, _ := ioutil.TempDir("", "tempdataset")
+	tmpdir, err := ioutil.TempDir("", "TestValidateGoodConfig")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempdataset := filepath.Join(tmpdir, "tempdataset")
+	err = os.Mkdir(tempdataset, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempdataset dir: %s", err.Error())
+	}
+
 	f, err := os.Create(filepath.Join(tempdataset, "ginvalidation.yaml"))
 	if err != nil {
 		t.Fatalf("Could not create yaml file: %s", err.Error())
 	}
 	defer f.Close()
+
 	_, err = f.WriteString("bidsconfig:\n  bidsroot: 'bids_example'")
 	if err != nil {
 		t.Fatalf("validateBIDS(valroot, resdir string) = %s", err.Error())
 	}
-	os.Mkdir(filepath.Join(tempdataset, "bids_example"), 0664)
+
+	os.Mkdir(filepath.Join(tempdataset, "bids_example"), 0755)
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
@@ -102,22 +131,40 @@ func TestValidateBIDSOK(t *testing.T) {
 }
 
 func TestValidateNIXOK(t *testing.T) {
-	resultfldr, _ := ioutil.TempDir("", "results")
-	tempdataset, _ := ioutil.TempDir("", "tempdataset")
+	tmpdir, err := ioutil.TempDir("", "TestValidateNIXOK")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempdataset := filepath.Join(tmpdir, "tempdataset")
+	err = os.Mkdir(tempdataset, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempdataset dir: %s", err.Error())
+	}
+
 	nix, err := ioutil.ReadFile("../../resources/nixdata.nix")
 	if err != nil {
 		t.Fatalf("validateNIX(valroot, resdir string) = %s", err.Error())
 	}
-	err = ioutil.WriteFile(filepath.Join(tempdataset, "nixdata.nix"), nix, 0664)
+	err = ioutil.WriteFile(filepath.Join(tempdataset, "nixdata.nix"), nix, 0755)
 	if err != nil {
 		t.Fatalf("validateNIX(valroot, resdir string) = %s", err.Error())
 	}
+
 	os.Mkdir(filepath.Join(tempdataset, ".git"), 0755)
 	nix = append([]byte("WTF_this_will_not_work"), nix...)
-	err = ioutil.WriteFile(filepath.Join(tempdataset, ".git", "nixdata_donottest.nix"), nix, 0664)
+	err = ioutil.WriteFile(filepath.Join(tempdataset, ".git", "nixdata_donottest.nix"), nix, 0755)
 	if err != nil {
 		t.Fatalf("validateNIX(valroot, resdir string) = %s", err.Error())
 	}
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
@@ -125,22 +172,40 @@ func TestValidateNIXOK(t *testing.T) {
 }
 
 func TestValidateODMLOK(t *testing.T) {
-	resultfldr, _ := ioutil.TempDir("", "results")
-	tempdataset, _ := ioutil.TempDir("", "tempdataset")
+	tmpdir, err := ioutil.TempDir("", "TestValidateODMLOK")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempdataset := filepath.Join(tmpdir, "tempdataset")
+	err = os.Mkdir(tempdataset, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempdataset dir: %s", err.Error())
+	}
+
 	odml, err := ioutil.ReadFile("../../resources/odmldata.odml")
 	if err != nil {
 		t.Fatalf("validateODML(valroot, resdir string) = %s", err.Error())
 	}
-	err = ioutil.WriteFile(filepath.Join(tempdataset, "odmldata.odml"), odml, 0664)
+	err = ioutil.WriteFile(filepath.Join(tempdataset, "odmldata.odml"), odml, 0755)
 	if err != nil {
 		t.Fatalf("validateODML(valroot, resdir string) = %s", err.Error())
 	}
+
 	os.Mkdir(filepath.Join(tempdataset, ".git"), 0755)
 	odml = append([]byte("WTF_this_will_not_work"), odml...)
-	err = ioutil.WriteFile(filepath.Join(tempdataset, ".git", "odmldata_donottest.odml"), odml, 0664)
+	err = ioutil.WriteFile(filepath.Join(tempdataset, ".git", "odmldata_donottest.odml"), odml, 0755)
 	if err != nil {
 		t.Fatalf("validateODML(valroot, resdir string) = %s", err.Error())
 	}
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	config.Set(srvcfg)
@@ -205,35 +270,57 @@ func TestValidatePub(t *testing.T) {
 }
 
 func TestValidateRepoDoesNotExists(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestValidateRepoDoesNotExists")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempfldr := filepath.Join(tmpdir, "temp")
+	err = os.Mkdir(tempfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempfldr dir: %s", err.Error())
+	}
+
+	tokenfldr := filepath.Join(tmpdir, "token")
+	err = os.MkdirAll(filepath.Join(tokenfldr, "by-repo"), 0755)
+	if err != nil {
+		t.Fatalf("error creating token dir: %s", err.Error())
+	}
+
 	username := "valid-testing"
 	reponame := "Testing"
-
-	token2 := "wtf"
+	token := "wtf"
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/validate/{validator}/{user}/{repo}", Validate).Methods("POST")
-	resultfldr, _ := ioutil.TempDir("", "results")
-	tempfldr, _ := ioutil.TempDir("", "temp")
-	tokenfldr, _ := ioutil.TempDir("", "token")
+
 	srvcfg := config.Read()
 	srvcfg.Dir.Result = resultfldr
 	srvcfg.Dir.Temp = tempfldr
 	srvcfg.Dir.Tokens = tokenfldr
 	config.Set(srvcfg)
+
 	var tok gweb.UserToken
 	tok.Username = username
-	tok.Token = token2
+	tok.Token = token
 	saveToken(tok)
-	os.Mkdir(filepath.Join(tokenfldr, "by-repo"), 0755)
 	linkToRepo(username, filepath.Join(username, "/", reponame))
+
 	r, _ := http.NewRequest("POST", filepath.Join("/validate/bids/", username, "/", reponame), bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
+
 	time.Sleep(5 * time.Second) // TODO HACK
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Tokens, "by-repo"))
 	status := w.Code
 	if status != http.StatusNotFound {
 		t.Fatalf("Validate(w http.ResponseWriter, r *http.Request) status code = %d", status)
@@ -331,22 +418,50 @@ func TestValidateODMLOK(t *testing.T) {
 }
 
 func testValidateOK(t *testing.T, validator string) {
+	tmpdir, err := ioutil.TempDir("", "testValidateOK")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempfldr := filepath.Join(tmpdir, "temp")
+	err = os.Mkdir(tempfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempfldr dir: %s", err.Error())
+	}
+
+	tokenfldr := filepath.Join(tmpdir, "token")
+	err = os.MkdirAll(filepath.Join(tokenfldr, "by-repo"), 0755)
+	if err != nil {
+		t.Fatalf("error creating token dir: %s", err.Error())
+	}
+
+	username := "valid-testing"
+	reponame := "Testing"
+
 	body := []byte('{"after": "8cea328d5ee9d6d8944bd06802f761f140a31653"}')
 	router := mux.NewRouter()
 	router.HandleFunc("/validate/{validator}/{user}/{repo}", Validate).Methods("POST")
+
 	srvcfg := config.Read()
-	srvcfg.Dir.Tokens = "."
-	os.Mkdir("tmp", 0755)
-	srvcfg.Dir.Temp = "./tmp"
+	srvcfg.Dir.Tokens = tokenfldr
+	srvcfg.Dir.Temp = tempfldr
 	srvcfg.GINAddresses.WebURL = weburl
 	srvcfg.GINAddresses.GitURL = giturl
 	config.Set(srvcfg)
+
 	var tok gweb.UserToken
 	tok.Username = username
 	tok.Token = token
 	saveToken(tok)
-	os.Mkdir(filepath.Join(srvcfg.Dir.Tokens, "by-repo"), 0755)
 	linkToRepo(username, filepath.Join(username, "/", reponame))
+
 	r, err := http.NewRequest("POST", filepath.Join("/validate", validator, username, reponame), bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("Validate(w http.ResponseWriter, r *http.Request) = %s", err.Error())
@@ -356,9 +471,8 @@ func testValidateOK(t *testing.T, validator string) {
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
+
 	time.Sleep(5 * time.Second) // TODO HACK
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Tokens, "by-repo"))
-	os.RemoveAll("tmp")
 	status := w.Code
 	if status != http.StatusOK {
 		t.Fatalf("Validate(w http.ResponseWriter, r *http.Request) status code = %d", status)
@@ -366,25 +480,51 @@ func testValidateOK(t *testing.T, validator string) {
 }
 
 func TestValidateBadgeFail(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestValidateRepoDoesNotExists")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempfldr := filepath.Join(tmpdir, "temp")
+	err = os.Mkdir(tempfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempfldr dir: %s", err.Error())
+	}
+
+	tokenfldr := filepath.Join(tmpdir, "token")
+	err = os.MkdirAll(filepath.Join(tokenfldr, "by-repo"), 0755)
+	if err != nil {
+		t.Fatalf("error creating token dir: %s", err.Error())
+	}
+
+	username := "valid-testing"
+	reponame := "Testing"
+
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/validate/{validator}/{user}/{repo}", Validate).Methods("POST")
+
 	srvcfg := config.Read()
-	resultfldr, _ := ioutil.TempDir("", "results")
-	tempfldr, _ := ioutil.TempDir("", "temp")
-	tokenfldr, _ := ioutil.TempDir("", "token")
 	srvcfg.GINAddresses.WebURL = weburl
 	srvcfg.GINAddresses.GitURL = giturl
 	srvcfg.Dir.Result = resultfldr
 	srvcfg.Dir.Temp = tempfldr
 	srvcfg.Dir.Tokens = tokenfldr
 	config.Set(srvcfg)
+
 	var tok gweb.UserToken
 	tok.Username = username
 	tok.Token = token
 	saveToken(tok)
-	os.Mkdir(filepath.Join(tokenfldr, "by-repo"), 0755)
 	linkToRepo(username, filepath.Join(username, "/", reponame))
+
 	r, err := http.NewRequest("POST", filepath.Join("/validate/bids/", username, "/", reponame), bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("Validate(w http.ResponseWriter, r *http.Request) = %s", err.Error())
@@ -394,6 +534,7 @@ func TestValidateBadgeFail(t *testing.T) {
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
+
 	time.Sleep(5 * time.Second) // TODO HACK
 	status := w.Code
 	if status != http.StatusOK {
@@ -402,32 +543,58 @@ func TestValidateBadgeFail(t *testing.T) {
 }
 
 func TestValidateTMPFail(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestValidateRepoDoesNotExists")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %s", err.Error())
+	}
+	defer os.RemoveAll(tmpdir)
+
+	resultfldr := filepath.Join(tmpdir, "results")
+	err = os.Mkdir(resultfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating results dir: %s", err.Error())
+	}
+
+	tempfldr := filepath.Join(tmpdir, "temp")
+	err = os.Mkdir(tempfldr, 0755)
+	if err != nil {
+		t.Fatalf("error creating tempfldr dir: %s", err.Error())
+	}
+
+	tokenfldr := filepath.Join(tmpdir, "token")
+	err = os.MkdirAll(filepath.Join(tokenfldr, "by-repo"), 0755)
+	if err != nil {
+		t.Fatalf("error creating token dir: %s", err.Error())
+	}
+
+	username := "valid-testing"
+	reponame := "Testing"
+
 	body := []byte("{}")
 	router := mux.NewRouter()
 	router.HandleFunc("/validate/{validator}/{user}/{repo}", Validate).Methods("POST")
+
 	srvcfg := config.Read()
-	resultfldr, _ := ioutil.TempDir("", "results")
-	tempfldr, _ := ioutil.TempDir("", "temp")
-	tokenfldr, _ := ioutil.TempDir("", "token")
 	srvcfg.GINAddresses.WebURL = weburl
 	srvcfg.GINAddresses.GitURL = giturl
 	srvcfg.Dir.Result = resultfldr
 	srvcfg.Dir.Temp = tempfldr
 	srvcfg.Dir.Tokens = tokenfldr
 	config.Set(srvcfg)
+
 	var tok gweb.UserToken
 	tok.Username = username
 	tok.Token = token
 	saveToken(tok)
-	os.Mkdir(filepath.Join(tokenfldr, "by-repo"), 0755)
 	linkToRepo(username, filepath.Join(username, "/", reponame))
+
 	r, _ := http.NewRequest("POST", filepath.Join("/validate/bids/", username, "/", reponame), bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	sig := hmac.New(sha256.New, []byte(srvcfg.Settings.HookSecret))
 	sig.Write(body)
 	r.Header.Add("X-Gogs-Signature", hex.EncodeToString(sig.Sum(nil)))
 	router.ServeHTTP(w, r)
-	os.RemoveAll(filepath.Join(srvcfg.Dir.Tokens, "by-repo"))
+
 	time.Sleep(5 * time.Second) //TODO HACK
 	status := w.Code
 	if status != http.StatusOK {

--- a/internal/web/validate_test.go
+++ b/internal/web/validate_test.go
@@ -55,7 +55,7 @@ func TestValidateNotYAML(t *testing.T) {
 
 func TestValidateGoodConfig(t *testing.T) {
 	f, _ := os.Create("testing-config.json")
-	f.WriteString("empty: \"true\"")
+	f.WriteString(`empty: "true"`)
 	f.Close()
 	valcfg, err := handleValidationConfig("testing-config.json")
 	os.RemoveAll("testing-config.json")
@@ -206,9 +206,6 @@ func TestValidatePub(t *testing.T) {
 		t.Fatalf("Validate(w http.ResponseWriter, r *http.Request) status code = %d", status)
 	}
 }
-
-/*
- */
 
 func TestValidateRepoDoesNotExists(t *testing.T) {
 	token2 := "wtf"

--- a/internal/web/validate_test.go
+++ b/internal/web/validate_test.go
@@ -20,9 +20,6 @@ import (
 	"time"
 )
 
-var username = "valid-testing"
-var reponame = "Testing"
-
 func TestValiateBadConfig(t *testing.T) {
 	valcfg, err := handleValidationConfig("wtf")
 	if err == nil {
@@ -208,6 +205,9 @@ func TestValidatePub(t *testing.T) {
 }
 
 func TestValidateRepoDoesNotExists(t *testing.T) {
+	username := "valid-testing"
+	reponame := "Testing"
+
 	token2 := "wtf"
 	body := []byte("{}")
 	router := mux.NewRouter()


### PR DESCRIPTION
This PR refactors tests on a basic level:
- unify test code formatting
- remove test wide variables
- consistently use and clean up temporary directories during all tests
- ensure errors are not ignored but thoroughly checked
- slim down test code by providing specific testutil functions for redundant code.