### PR TITLE
Access token removal fix on hook removal

### DIFF
--- a/cmd/ginvalid/main.go
+++ b/cmd/ginvalid/main.go
@@ -62,13 +62,13 @@ func startupCheck(srvcfg config.ServerCfg) {
 		os.Exit(-1)
 	}
 
-	log.ShowWrite("[Warmup] using temp directory: '%s'", srvcfg.Dir.Temp)
-	log.ShowWrite("[Warmup] using results directory '%s'", srvcfg.Dir.Result)
+	log.ShowWrite("[Warmup] using temp directory: %q", srvcfg.Dir.Temp)
+	log.ShowWrite("[Warmup] using results directory %q", srvcfg.Dir.Result)
 
 	// Check bids-validator is installed
 	outstr, err := helpers.AppVersionCheck(srvcfg.Exec.BIDS)
 	if err != nil {
-		log.ShowWrite("[Error] checking bids-validator '%s'", err.Error())
+		log.ShowWrite("[Error] checking bids-validator %q", err.Error())
 		os.Exit(-1)
 	}
 	log.ShowWrite("[Warmup] using bids-validator v%s", strings.TrimSpace(outstr))
@@ -110,7 +110,7 @@ func commcheck(srvcfg config.ServerCfg) {
 	cli := ginclient.New("gin")
 	err = cli.Login(srvcfg.Settings.GINUser, srvcfg.Settings.GINPassword, srvcfg.Settings.ClientID)
 	if err != nil {
-		log.ShowWrite("Failed to login to GIN server: %s", err.Error())
+		log.ShowWrite("[Error] Failed to login to GIN server: %s", err.Error())
 		os.Exit(-1)
 	}
 	log.ShowWrite("[Warmup] GIN server configuration OK")
@@ -171,7 +171,7 @@ func main() {
 		port = srvcfg.Settings.Port
 	}
 	port = fmt.Sprintf(":%s", port)
-	log.ShowWrite("[Warmup] using port: '%s'", port)
+	log.ShowWrite("[Warmup] using port: %q", port)
 
 	log.ShowWrite("[Warmup] registering routes")
 	router := mux.NewRouter()

--- a/internal/helpers/utils.go
+++ b/internal/helpers/utils.go
@@ -12,10 +12,10 @@ func ValidDirectory(path string) bool {
 	var fi os.FileInfo
 	var err error
 	if fi, err = os.Stat(path); err != nil {
-		log.ShowWrite("[Error] checking directory '%s': '%s'\n", path, err.Error())
+		log.ShowWrite("[Error] checking directory %q: %q", path, err.Error())
 		return false
 	} else if !fi.IsDir() {
-		log.ShowWrite("[Error] invalid directory '%s'\n", fi.Name())
+		log.ShowWrite("[Error] invalid directory %q", fi.Name())
 		return false
 	}
 	return true

--- a/internal/web/fail.go
+++ b/internal/web/fail.go
@@ -13,21 +13,21 @@ import (
 // fail logs an error and renders an error page with the given message,
 // returning the given status code to the user.
 func fail(w http.ResponseWriter, r *http.Request, status int, message string) {
-	log.Write("[error] %s", message)
+	log.ShowWrite("[Info] displaying error message %s", message)
 	w.WriteHeader(status)
 
 	tmpl := template.New("layout")
 	tmpl, err := tmpl.Parse(templates.Layout)
 	if err != nil {
-		log.Write("[Error] failed to parse html layout page. Displaying error message without layout.")
+		log.ShowWrite("[Error] failed to parse html layout page. Displaying error message without layout: %s", err.Error())
 		tmpl = template.New("content")
 	}
 	tmpl, err = tmpl.Parse(templates.Fail)
 	if err != nil {
-		log.Write("[Error] failed to render fail page. Displaying plain error message.")
+		log.ShowWrite("[Error] failed to render fail page. Displaying plain error message: %s", err.Error())
 		_, err = w.Write([]byte(message))
 		if err != nil {
-			log.Write("[Error] failed to write plain error message: %s", err.Error())
+			log.ShowWrite("[Error] failed to write plain error message: %s", err.Error())
 		}
 		return
 	}
@@ -54,6 +54,6 @@ func fail(w http.ResponseWriter, r *http.Request, status int, message string) {
 	}
 	err = tmpl.Execute(w, &errinfo)
 	if err != nil {
-		log.Write("[Error] failed to parse error info to page: %s", err.Error())
+		log.ShowWrite("[Error] failed to parse error info to page: %s", err.Error())
 	}
 }

--- a/internal/web/ginutils.go
+++ b/internal/web/ginutils.go
@@ -114,7 +114,7 @@ func isGitRepo(path string) bool {
 // This function is a modified version of the gin-client CloneRepo method.
 func remoteCloneRepo(gincl *ginclient.Client, repopath, clonedir string, clonechan chan<- gingit.RepoFileStatus) {
 	defer close(clonechan)
-	log.ShowWrite("[Info] Starting remoteCloneRepo")
+	log.ShowWrite("[Info] starting remoteCloneRepo")
 	clonestatus := make(chan gingit.RepoFileStatus)
 	remotepath := fmt.Sprintf("%s/%s", gincl.GitAddress(), repopath)
 
@@ -438,8 +438,7 @@ func remoteAnnexGet(gitdir string, getchan chan<- gingit.RepoFileStatus, rawMode
 			err = json.Unmarshal(outline, &getresult)
 			if err != nil || getresult.Command == "" {
 				// Couldn't parse output
-				log.ShowWrite("[Warning] Could not parse 'git annex get' output")
-				log.ShowWrite(string(outline))
+				log.ShowWrite("[Warning] Could not parse 'git annex get' output: %s", string(outline))
 				// TODO: Print error at the end: Command succeeded but there was an error understanding the output
 				continue
 			}
@@ -490,7 +489,7 @@ func remoteCommitCheckout(gitdir, hash string) error {
 	cmd.Args = cmdargs
 	_, stderr, err := cmd.OutputError()
 	if err != nil {
-		log.ShowWrite("[Error] %s; %s", err.Error(), string(stderr))
+		log.ShowWrite("[Error] err: %s; stderr: %s", err.Error(), string(stderr))
 		return fmt.Errorf(string(stderr))
 	}
 	return nil

--- a/internal/web/results.go
+++ b/internal/web/results.go
@@ -120,11 +120,11 @@ func Results(w http.ResponseWriter, r *http.Request) {
 	repo := vars["repo"]
 	validator := strings.ToLower(vars["validator"])
 	if !helpers.SupportedValidator(validator) {
-		log.ShowWrite("[Error] unsupported validator '%s'\n", validator)
+		log.ShowWrite("[Error] unsupported validator '%s'", validator)
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("404 Nothing to see here...")))
 		return
 	}
-	log.ShowWrite("[Info] '%s' results for repo '%s/%s'\n", validator, user, repo)
+	log.ShowWrite("[Info] %q results for repo '%s/%s'", validator, user, repo)
 
 	srvcfg := config.Read()
 	resID, ok := vars["id"]
@@ -143,7 +143,7 @@ func Results(w http.ResponseWriter, r *http.Request) {
 	fp := filepath.Join(resdir, srvcfg.Label.ResultsBadge)
 	badge, err := ioutil.ReadFile(fp)
 	if err != nil {
-		log.ShowWrite("[Error] serving '%s/%s' badge: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] serving '%s/%s' badge: %s", user, repo, err.Error())
 	}
 
 	fp = filepath.Join(resdir, srvcfg.Label.ResultsFile)
@@ -176,13 +176,13 @@ func notValidatedYet(w http.ResponseWriter, r *http.Request, badge []byte, valid
 	tmpl := template.New("layout")
 	tmpl, err := tmpl.Parse(templates.Layout)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.NotValidatedYet)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -213,7 +213,7 @@ func notValidatedYet(w http.ResponseWriter, r *http.Request, badge []byte, valid
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -223,13 +223,13 @@ func renderInProgress(w http.ResponseWriter, r *http.Request, badge []byte, vali
 	tmpl := template.New("layout")
 	tmpl, err := tmpl.Parse(templates.Layout)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.GenericResults)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -252,7 +252,7 @@ func renderInProgress(w http.ResponseWriter, r *http.Request, badge []byte, vali
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -278,7 +278,7 @@ func resultsHistory(validator, user, repo string) ResultsHistoryStruct {
 	resdir := filepath.Join(srvcfg.Dir.Result, validator, user, repo)
 	fileinfos, err := myReadDir(resdir)
 	if err != nil {
-		log.ShowWrite("[Error] cannot retrieve results history '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] cannot retrieve results history '%s/%s' result: %s", user, repo, err.Error())
 		return ret
 	}
 	for _, i := range fileinfos {
@@ -292,7 +292,7 @@ func resultsHistory(validator, user, repo string) ResultsHistoryStruct {
 			var res Result
 			res.Href = pth
 			res.Alt = i.Name()
-			res.Text1 = i.ModTime().Format("2006-01-02")
+			res.Text1 = i.ModTime().UTC().Format("2006-01-02")
 			res.Text2 = i.ModTime().Format("15:04:05")
 			res.Badge = template.HTML(badge)
 			ret.Results = append(ret.Results, res)
@@ -307,7 +307,7 @@ func renderBIDSResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 	err := json.Unmarshal(content, &resBIDS)
 	errMsg := ""
 	if err != nil {
-		log.ShowWrite("[Error] unmarshalling '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] unmarshalling '%s/%s' result: %s", user, repo, err.Error())
 		errMsg = "Could not validate format as BIDS."
 	}
 
@@ -315,13 +315,13 @@ func renderBIDSResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 	tmpl := template.New("layout")
 	tmpl, err = tmpl.Parse(templates.Layout)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.BidsResults)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -345,7 +345,7 @@ func renderBIDSResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -357,13 +357,13 @@ func renderNIXResults(w http.ResponseWriter, r *http.Request, badge []byte, cont
 	tmpl := template.New("layout")
 	tmpl, err := tmpl.Parse(templates.Layout)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.GenericResults)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -386,7 +386,7 @@ func renderNIXResults(w http.ResponseWriter, r *http.Request, badge []byte, cont
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -398,13 +398,13 @@ func renderODMLResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 	tmpl := template.New("layout")
 	tmpl, err := tmpl.Parse(templates.Layout)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
 	tmpl, err = tmpl.Parse(templates.GenericResults)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}
@@ -427,7 +427,7 @@ func renderODMLResults(w http.ResponseWriter, r *http.Request, badge []byte, con
 
 	err = tmpl.ExecuteTemplate(w, "layout", info)
 	if err != nil {
-		log.ShowWrite("[Error] '%s/%s' result: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] '%s/%s' result: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("500 Something went wrong...")))
 		return
 	}

--- a/internal/web/status.go
+++ b/internal/web/status.go
@@ -19,20 +19,20 @@ import (
 func Status(w http.ResponseWriter, r *http.Request) {
 	validator := mux.Vars(r)["validator"]
 	if !helpers.SupportedValidator(validator) {
-		log.Write("[Error] unsupported validator '%s'\n", validator)
+		log.ShowWrite("[Error] unsupported validator %q", validator)
 		http.ServeContent(w, r, "unavailable", time.Now(), bytes.NewReader([]byte("404 Nothing to see here...")))
 		return
 	}
 	user := mux.Vars(r)["user"]
 	repo := mux.Vars(r)["repo"]
-	log.Write("[Info] '%s' status for repo '%s/%s'\n", validator, user, repo)
+	log.ShowWrite("[Info] %q status for repo '%s/%s'", validator, user, repo)
 
 	srvcfg := config.Read()
 
 	fp := filepath.Join(srvcfg.Dir.Result, "bids", user, repo, srvcfg.Label.ResultsFolder, srvcfg.Label.ResultsBadge)
 	content, err := ioutil.ReadFile(fp)
 	if err != nil {
-		log.Write("[Error] serving '%s/%s' status: %s\n", user, repo, err.Error())
+		log.ShowWrite("[Error] serving '%s/%s' status: %s", user, repo, err.Error())
 		http.ServeContent(w, r, "unavailable.svg", time.Now(), bytes.NewReader([]byte(resources.UnavailableBadge)))
 		return
 	}

--- a/internal/web/token.go
+++ b/internal/web/token.go
@@ -40,7 +40,7 @@ func loadToken(path string) (gweb.UserToken, error) {
 	ut := gweb.UserToken{}
 	tokenfile, err := os.Open(path)
 	if err != nil {
-		log.Write("[Error] Failed to load token from %s", path)
+		log.ShowWrite("[Error] failed to load token from %s: %s", path, err.Error())
 		return ut, err
 	}
 	defer tokenfile.Close()
@@ -60,7 +60,7 @@ func linkToSession(username string, sessionid string) error {
 	// this will also fix outdated tokens. Log any error but try to continue.
 	err := os.Remove(sidfile)
 	if err != nil {
-		log.Write("[Error] removing session link: %s", err.Error())
+		log.ShowWrite("[Error] removing session link: %s", err.Error())
 	}
 	return os.Symlink(utfile, sidfile)
 }
@@ -86,7 +86,7 @@ func linkToRepo(username string, repopath string) error {
 	// this will also fix outdated tokens Log any error but try to continue.
 	err := os.Remove(sidfile)
 	if err != nil {
-		log.Write("[Error] removing session link: %s", err.Error())
+		log.ShowWrite("[Error] removing session link: %s", err.Error())
 	}
 	return os.Symlink(utfile, sidfile)
 }


### PR DESCRIPTION
On hook removal the validation hook access tokens for a repository are now only removed, if there are no more remaining active hooks left. Closes #105.