### PR TITLE
Validation fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN go build ./cmd/ginvalid
 ### ============================ ###
 
 # RUNNER IMAGE
-FROM alpine:3.14
+FROM alpine:3.16
 
 # Runtime deps
 RUN echo http://dl-2.alpinelinux.org/alpine/edge/community/ >> /etc/apk/repositories

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,8 @@ RUN apk --no-cache --no-progress add \
         py3-tomli \
         py3-pip \
         python3-dev \
-        py3-lxml \
-        py3-h5py \
-        py3-numpy
+        py3-numpy \
+        py3-h5py
 
 # Install the BIDS validator
 RUN npm install -g bids-validator
@@ -63,8 +62,7 @@ COPY ./scripts/odml-validate /bin
 COPY ./resources /resources
 
 # Install NIXPy for NIX validation
-# Use master branch until new beta is released
-RUN pip3 install --no-cache-dir -U git+https://github.com/G-Node/nixpy@master
+RUN pip3 install --no-cache-dir nixio
 
 # Copy git-annex from builder image
 COPY --from=binbuilder /git-annex /git-annex

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ COPY ./assets /assets
 
 # Test validation
 RUN odml-validate /resources/odmldata.odml
-RUN nixio -h
 RUN nixio validate /resources/nixdata.nix
 RUN bids-validator --version
 

--- a/internal/web/ginutils.go
+++ b/internal/web/ginutils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -493,4 +494,20 @@ func remoteCommitCheckout(gitdir, hash string) error {
 		return fmt.Errorf(string(stderr))
 	}
 	return nil
+}
+
+// getRepoCommit uses a gin client connection to query the latest commit
+// of a provided gin repository and returns either an error or
+// the commit hash as a string.
+func getRepoCommit(client *ginclient.Client, repo string) (string, error) {
+	reqpath := fmt.Sprintf("api/v1/repos/%s/commits/refs/heads/master", repo)
+	resp, err := client.Get(reqpath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest commit hash for %q: %s", repo, err.Error())
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read latest commit hash from response for %q: %s", repo, err.Error())
+	}
+	return string(data), nil
 }

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -165,6 +165,21 @@ func validateBIDS(valroot, resdir string) error {
 	return nil
 }
 
+// runNIXvalidation runs the nix validator on a specified file and
+// returns the results of the validation.
+func runNIXvalidation(nixexec, nixfile string) ([]byte, error) {
+	var out, serr bytes.Buffer
+	cmd := exec.Command(nixexec, "validate", nixfile)
+	out.Reset()
+	serr.Reset()
+	cmd.Stdout = &out
+	cmd.Stderr = &serr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("[Error] running NIX validation %q, %q", err.Error(), serr.String())
+	}
+	return out.Bytes(), nil
+}
+
 // validateNIX runs the NIX validator on the specified repository in 'path'
 // and saves the results to the appropriate document for later viewing.
 func validateNIX(valroot, resdir string) error {

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -356,7 +356,7 @@ func validateODML(valroot, resdir string) error {
 }
 
 func runValidator(validator, repopath, commit string, gcl *ginclient.Client) string {
-	checkoutCommit := commit == "HEAD"
+	checkoutCommit := commit != "HEAD"
 
 	respath := filepath.Join(validator, repopath, commit)
 	go func() {

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -112,7 +112,6 @@ func validateBIDS(valroot, resdir string) error {
 	args = append(args, "--json")
 	args = append(args, valroot)
 
-	// cmd = exec.Command(srvcfg.Exec.BIDS, validateNifti, "--json", valroot)
 	var out, serr bytes.Buffer
 	cmd := exec.Command(srvcfg.Exec.BIDS, args...)
 	out.Reset()
@@ -121,9 +120,7 @@ func validateBIDS(valroot, resdir string) error {
 	cmd.Stderr = &serr
 	// cmd.Dir = tmpdir
 	if err := cmd.Run(); err != nil {
-		err = fmt.Errorf("[Error] running bids validation (%s): %q, %q", valroot, err.Error(), serr.String())
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] running bids validation (%s): %q, %q", valroot, err.Error(), serr.String())
 	}
 
 	// We need this for both the writing of the result and the badge
@@ -133,9 +130,7 @@ func validateBIDS(valroot, resdir string) error {
 	outFile := filepath.Join(resdir, srvcfg.Label.ResultsFile)
 	err := ioutil.WriteFile(outFile, []byte(output), os.ModePerm)
 	if err != nil {
-		err = fmt.Errorf("[Error] writing results file for %q", valroot)
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] writing results file for %q", valroot)
 	}
 
 	// Write proper badge according to result
@@ -143,9 +138,7 @@ func validateBIDS(valroot, resdir string) error {
 	var parseBIDS BidsRoot
 	err = json.Unmarshal(output, &parseBIDS)
 	if err != nil {
-		err = fmt.Errorf("[Error] unmarshalling results json: %s", err.Error())
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] unmarshalling results json: %s", err.Error())
 	}
 
 	if len(parseBIDS.Issues.Errors) > 0 {
@@ -156,9 +149,7 @@ func validateBIDS(valroot, resdir string) error {
 
 	err = ioutil.WriteFile(outBadge, []byte(content), os.ModePerm)
 	if err != nil {
-		err = fmt.Errorf("[Error] writing results badge for %q", valroot)
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] writing results badge for %q", valroot)
 	}
 
 	log.ShowWrite("[Info] finished validating repo at %q", valroot)
@@ -301,9 +292,7 @@ func validateODML(valroot, resdir string) error {
 
 	err := filepath.Walk(valroot, odmlfinder)
 	if err != nil {
-		err = fmt.Errorf("[Error] while looking for odML files in repository at %q: %s", valroot, err.Error())
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] while looking for odML files in repository at %q: %s", valroot, err.Error())
 	}
 
 	outBadge := filepath.Join(resdir, srvcfg.Label.ResultsBadge)
@@ -315,9 +304,7 @@ func validateODML(valroot, resdir string) error {
 	cmd.Stdout = &out
 	cmd.Stderr = &serr
 	if err = cmd.Run(); err != nil {
-		err = fmt.Errorf("[Error] running odML validation (%s): '%s', '%s'", valroot, err.Error(), serr.String())
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] running odML validation (%s): '%s', '%s'", valroot, err.Error(), serr.String())
 	}
 
 	// We need this for both the writing of the result and the badge
@@ -339,16 +326,12 @@ func validateODML(valroot, resdir string) error {
 	outFile := filepath.Join(resdir, srvcfg.Label.ResultsFile)
 	err = ioutil.WriteFile(outFile, output, os.ModePerm)
 	if err != nil {
-		err = fmt.Errorf("[Error] writing results file for %q", valroot)
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] writing results file for %q", valroot)
 	}
 
 	err = ioutil.WriteFile(outBadge, badge, os.ModePerm)
 	if err != nil {
-		err = fmt.Errorf("[Error] writing results badge for %q", valroot)
-		log.ShowWrite(err.Error())
-		return err
+		return fmt.Errorf("[Error] writing results badge for %q", valroot)
 	}
 
 	log.ShowWrite("[Info] finished validating repo at %q", valroot)


### PR DESCRIPTION
This PR fixes various issues when running the validation variants:
- when a NIX file cannot be opened, the occurrence is logged as a validation error and the validation continues with the next NIX file. Closes #106.
- provide the appropriate error when the BIDS validator is not run from the root BIDS folder structure. Closes #107.
- when running a public validation, the stored result is now stored using the actual HEAD commit hash. 

Further the PR
- upgrades the Docker "Runner image" version to `alpine:3.16`
- upgrades and simplifies the Docker nixio build